### PR TITLE
Allow specifying the server version

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ module ModelContextProtocol
     def index
       server = ModelContextProtocol::Server.new(
         name: "my_server",
+        version: "1.0.0",
         tools: [SomeTool, AnotherTool],
         prompts: [MyPrompt],
         server_context: { user_id: current_user.id },

--- a/examples/stdio_server.rb
+++ b/examples/stdio_server.rb
@@ -54,6 +54,7 @@ end
 # Set up the server
 server = MCP::Server.new(
   name: "example_server",
+  version: "1.0.0",
   tools: [ExampleTool],
   prompts: [ExamplePrompt],
   resources: [

--- a/lib/model_context_protocol/server.rb
+++ b/lib/model_context_protocol/server.rb
@@ -6,6 +6,8 @@ require_relative "methods"
 
 module ModelContextProtocol
   class Server
+    DEFAULT_VERSION = "0.1.0"
+
     class RequestHandlerError < StandardError
       attr_reader :error_type
       attr_reader :original_error
@@ -20,10 +22,11 @@ module ModelContextProtocol
 
     include Instrumentation
 
-    attr_accessor :name, :tools, :prompts, :resources, :server_context, :configuration, :capabilities
+    attr_accessor :name, :version, :tools, :prompts, :resources, :server_context, :configuration, :capabilities
 
     def initialize(
       name: "model_context_protocol",
+      version: DEFAULT_VERSION,
       tools: [],
       prompts: [],
       resources: [],
@@ -33,6 +36,7 @@ module ModelContextProtocol
       capabilities: { prompts: {}, resources: {}, tools: {} }
     )
       @name = name
+      @version = version
       @tools = tools.to_h { |t| [t.name_value, t] }
       @prompts = prompts.to_h { |p| [p.name_value, p] }
       @resources = resources
@@ -153,7 +157,7 @@ module ModelContextProtocol
     def server_info
       @server_info ||= {
         name:,
-        version: ModelContextProtocol::VERSION,
+        version:,
       }
     end
 

--- a/test/model_context_protocol/server_test.rb
+++ b/test/model_context_protocol/server_test.rb
@@ -51,6 +51,7 @@ module ModelContextProtocol
 
       @server = Server.new(
         name: @server_name,
+        version: "1.2.3",
         tools: [@tool, @tool_that_raises],
         prompts: [@prompt],
         resources: [@resource],
@@ -120,7 +121,7 @@ module ModelContextProtocol
           },
           "serverInfo": {
             "name": @server_name,
-            "version": ModelContextProtocol::VERSION,
+            "version": "1.2.3",
           },
         },
       }
@@ -646,6 +647,18 @@ module ModelContextProtocol
 
       response = @server.handle(request)
       assert_equal Configuration::DEFAULT_PROTOCOL_VERSION, response[:result][:protocolVersion]
+    end
+
+    test "server uses default version when not configured" do
+      server = Server.new(name: "test_server")
+      request = {
+        jsonrpc: "2.0",
+        method: "initialize",
+        id: 1,
+      }
+
+      response = server.handle(request)
+      assert_equal Server::DEFAULT_VERSION, response[:result][:serverInfo][:version]
     end
 
     test "#define_tool adds a tool to the server" do


### PR DESCRIPTION
I added a constructor parameter to the `Server` class to specify a server version.

## Motivation and Context
Currently the server uses the gem version as version returned to the client. But the gem is just the framework used to built the actual server.

## How Has This Been Tested?
I tried it out a dummy server out with the official mcp inspector.

## Breaking Changes
It's an additional optional argument so it should not break anything.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
