### PR TITLE
Auto determine capabilities

### DIFF
--- a/lib/model_context_protocol/server.rb
+++ b/lib/model_context_protocol/server.rb
@@ -22,7 +22,6 @@ module ModelContextProtocol
 
     include Instrumentation
 
-
     attr_writer :capabilities
     attr_accessor :name, :version, :tools, :prompts, :resources, :server_context, :configuration
 

--- a/lib/model_context_protocol/server.rb
+++ b/lib/model_context_protocol/server.rb
@@ -155,7 +155,15 @@ module ModelContextProtocol
     end
 
     def determine_capabilities
-      { prompts: {}, resources: {}, tools: {} }
+      defines_prompts = @prompts.any? || @handlers[Methods::PROMPTS_LIST] != method(:list_prompts)
+      defines_tools = @tools.any? || @handlers[Methods::TOOLS_LIST] != method(:list_tools)
+      defines_resources = @resources.any? || @handlers[Methods::RESOURCES_LIST] != method(:list_resources)
+      defines_resource_templates = @resource_templates.any? || @handlers[Methods::RESOURCES_TEMPLATES_LIST] != method(:list_resource_templates)
+      {
+        prompts: defines_prompts ? {} : nil,
+        resources: defines_resources || defines_resource_templates ? {} : nil,
+        tools: defines_tools ? {} : nil,
+      }.compact
     end
 
     def server_info

--- a/test/model_context_protocol/server_test.rb
+++ b/test/model_context_protocol/server_test.rb
@@ -726,5 +726,67 @@ module ModelContextProtocol
       response = server.handle(request)
       assert_equal custom_version, response[:result][:protocolVersion]
     end
+
+    test "has tool capability only if tools or a tools_list_handler is defined" do
+      server_with_tools = Server.new(name: "test_server", tools: [@tool])
+
+      assert_includes server_with_tools.capabilities, :tools
+
+      server_with_handler = Server.new(name: "test_server")
+      server_with_handler.tools_list_handler do
+        [{ name: "test_tool", description: "Test tool" }]
+      end
+
+      assert_includes server_with_handler.capabilities, :tools
+
+      server_without_tools = Server.new(name: "test_server")
+
+      refute_includes server_without_tools.capabilities, :tools
+    end
+
+    test "has prompt capability only if prompts or a prompts_list_handler is defined" do
+      server_with_prompts = Server.new(name: "test_server", prompts: [@prompt])
+
+      assert_includes server_with_prompts.capabilities, :prompts
+
+      server_with_handler = Server.new(name: "test_server")
+      server_with_handler.prompts_list_handler do
+        [{ name: "test_prompt", description: "Test prompt" }]
+      end
+
+      assert_includes server_with_handler.capabilities, :prompts
+
+      server_without_prompts = Server.new(name: "test_server")
+
+      refute_includes server_without_prompts.capabilities, :prompts
+    end
+
+    test "has resources capability only if resources, template or custom handler is defined" do
+      server_with_resources = Server.new(name: "test_server", resources: [@resource])
+
+      assert_includes server_with_resources.capabilities, :resources
+
+      server_with_resource_template = Server.new(name: "test_server", resource_templates: [@resource_template])
+
+      assert_includes server_with_resource_template.capabilities, :resources
+
+      server_with_resources_list_handler = Server.new(name: "test_server")
+      server_with_resources_list_handler.resources_list_handler do
+        [{ uri: "test_resource", name: "Test resource", description: "Test resource" }]
+      end
+
+      assert_includes server_with_resources_list_handler.capabilities, :resources
+
+      server_with_resources_templates_list_handler = Server.new(name: "test_server")
+      server_with_resources_templates_list_handler.resources_templates_list_handler do
+        [{ uri_template: "test_resource/{id}", name: "Test resource", description: "Test resource" }]
+      end
+
+      assert_includes server_with_resources_templates_list_handler.capabilities, :resources
+
+      server_without_resources = Server.new(name: "test_server")
+
+      refute_includes server_without_resources.capabilities, :resources
+    end
   end
 end


### PR DESCRIPTION
I added logic to auto-determine a server's capabilities based on the protocol features actually used in the server.
- If the server has at least 1 tool or defines a custom `tools_list_handler`, it returns the `tools` capability
- If the server has at least 1 prompt or defines a custom `prompts_list_handler`, it returns the `prompts` capability
- If the server has at least 1 resource or template or defines a custom list handler for either of those it returns the `resources` capability

## Motivation and Context
I found it unnecessary that you have to manually specify the capabilities when they could be actually auto-determined from the server definition.

## How Has This Been Tested?
I tried out a few patterns in my local mcp inspector

## Breaking Changes
This should not be a breaking change since an empty tool list and no capability should make no practical difference to a procotol conform MCP client.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
I was even thinking about completely removing the ability to set or override the capabilities manually but maybe that would have been going too far - and it would have also made testing of `ensure_capability!` more complicated
