### PR TITLE
Support Sorbet typed tools

### DIFF
--- a/lib/model_context_protocol/server.rb
+++ b/lib/model_context_protocol/server.rb
@@ -197,7 +197,8 @@ module ModelContextProtocol
       end
 
       begin
-        call_params = tool.method(:call).parameters.flatten
+        call_params = tool_call_parameters(tool)
+
         if call_params.include?(:server_context)
           tool.call(**arguments.transform_keys(&:to_sym), server_context:).to_h
         else
@@ -256,6 +257,25 @@ module ModelContextProtocol
     def index_resources_by_uri(resources)
       resources.each_with_object({}) do |resource, hash|
         hash[resource.uri] = resource
+      end
+    end
+
+    def tool_call_parameters(tool)
+      method_def = tool_call_method_def(tool)
+      method_def.parameters.flatten
+    end
+
+    def tool_call_method_def(tool)
+      method = tool.method(:call)
+
+      if defined?(T::Utils) && T::Utils.respond_to?(:signature_for_method)
+        sorbet_typed_method_definition = T::Utils.signature_for_method(method)&.method
+
+        # Return the Sorbet typed method definition if it exists, otherwise fallback to original method
+        # definition if Sorbet is defined but not used by this tool.
+        sorbet_typed_method_definition || method
+      else
+        method
       end
     end
   end

--- a/model_context_protocol.gemspec
+++ b/model_context_protocol.gemspec
@@ -29,4 +29,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency("json_rpc_handler", "~> 0.1")
   spec.add_development_dependency("activesupport")
+  spec.add_development_dependency("sorbet-static-and-runtime")
 end

--- a/test/model_context_protocol/tool_test.rb
+++ b/test/model_context_protocol/tool_test.rb
@@ -18,7 +18,7 @@ module ModelContextProtocol
       )
 
       class << self
-        def call(message, server_context: nil)
+        def call(message:, server_context: nil)
           Tool::Response.new([{ type: "text", content: "OK" }])
         end
       end
@@ -43,7 +43,7 @@ module ModelContextProtocol
 
     test "#call invokes the tool block and returns the response" do
       tool = TestTool
-      response = tool.call("test")
+      response = tool.call(message: "test")
       assert_equal response.content, [{ type: "text", content: "OK" }]
       assert_equal response.is_error, false
     end
@@ -210,26 +210,19 @@ module ModelContextProtocol
         tool_name "test_tool"
         description "a test tool for testing"
         input_schema({ properties: { message: { type: "string" } }, required: ["message"] })
-        annotations(
-          title: "Test Tool",
-          read_only_hint: true,
-          destructive_hint: false,
-          idempotent_hint: true,
-          open_world_hint: false,
-        )
 
         class << self
           extend T::Sig
 
           sig { params(message: String, server_context: T.nilable(T.untyped)).returns(Tool::Response) }
-          def call(message, server_context: nil)
+          def call(message:, server_context: nil)
             Tool::Response.new([{ type: "text", content: "OK" }])
           end
         end
       end
 
       tool = TypedTestTool
-      response = tool.call("test")
+      response = tool.call(message: "test")
       assert_equal response.content, [{ type: "text", content: "OK" }]
       assert_equal response.is_error, false
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,6 +13,8 @@ require "mocha/minitest"
 require "active_support"
 require "active_support/test_case"
 
+require "sorbet-runtime"
+
 require_relative "instrumentation_test_helper"
 
 Minitest::Reporters.use!(Minitest::Reporters::ProgressReporter.new)


### PR DESCRIPTION
## Motivation and Context

Fixes https://github.com/modelcontextprotocol/ruby-sdk/issues/9

## How Has This Been Tested?

* Test coverage added to tool_test.rb, server_test.rb
* Tested with a simple Rails server and tool described in https://github.com/modelcontextprotocol/ruby-sdk/issues/9

Second commit updates tools defined in tool_test.rb unit tests use the expected kwarg syntax.

## Breaking Changes

None.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed