### PR TITLE
Fix .gitignore entry for `Gemfile.lock`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@
 /pkg/
 /spec/reports/
 /tmp/
-.Gemfile.lock
+Gemfile.lock


### PR DESCRIPTION
The `Gemfile.lock` entry has a `.` in front which prevents it from being ignored.