### PR TITLE
Fix a typo

### DIFF
--- a/lib/model_context_protocol/server.rb
+++ b/lib/model_context_protocol/server.rb
@@ -252,7 +252,7 @@ module ModelContextProtocol
       @resources.map(&:to_h)
     end
 
-    # Server implementation should set read_resource_handler to override no-op default
+    # Server implementation should set `resources_read_handler` to override no-op default
     def read_resource_no_content(request)
       add_instrumentation_data(method: Methods::RESOURCES_READ)
       add_instrumentation_data(resource_uri: request[:uri])


### PR DESCRIPTION
## Motivation and Context

The method that overrides `Methods::RESOURCES_READ` is named `resources_read_handler`, not `read_resource_handler`:
https://github.com/modelcontextprotocol/ruby-sdk/blob/18f3e87/lib/model_context_protocol/server.rb#L97-L99

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
