### PR TITLE
Remove redundant `require_relative`

### DIFF
--- a/lib/model_context_protocol.rb
+++ b/lib/model_context_protocol.rb
@@ -18,7 +18,6 @@ require_relative "model_context_protocol/prompt/message"
 require_relative "model_context_protocol/prompt/result"
 require_relative "model_context_protocol/version"
 require_relative "model_context_protocol/configuration"
-require_relative "model_context_protocol/methods"
 
 module ModelContextProtocol
   class << self


### PR DESCRIPTION
## Motivation and Context

This PR removes a redundant require statement that is already present in the `server.rb`: https://github.com/modelcontextprotocol/ruby-sdk/blob/89ef9d8/lib/model_context_protocol/server.rb#L5

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
