### PR TITLE
Fix incorrect capabilities handling for `completion/complete`

### DIFF
--- a/lib/model_context_protocol/methods.rb
+++ b/lib/model_context_protocol/methods.rb
@@ -36,7 +36,7 @@ module ModelContextProtocol
 
     def ensure_capability!(method, capabilities)
       case method
-      when PROMPTS_GET, PROMPTS_LIST, COMPLETION_COMPLETE
+      when PROMPTS_GET, PROMPTS_LIST
         unless capabilities[:prompts]
           raise MissingRequiredCapabilityError.new(method, :prompts)
         end
@@ -55,6 +55,10 @@ module ModelContextProtocol
       when SAMPLING_CREATE_MESSAGE
         unless capabilities[:sampling]
           raise MissingRequiredCapabilityError.new(method, :sampling)
+        end
+      when COMPLETION_COMPLETE
+        unless capabilities[:completions]
+          raise MissingRequiredCapabilityError.new(method, :completions)
         end
       when LOGGING_SET_LEVEL
         # Logging is unsupported by the Server

--- a/lib/model_context_protocol/server.rb
+++ b/lib/model_context_protocol/server.rb
@@ -60,6 +60,7 @@ module ModelContextProtocol
         # No op handlers for currently unsupported methods
         Methods::RESOURCES_SUBSCRIBE => ->(_) {},
         Methods::RESOURCES_UNSUBSCRIBE => ->(_) {},
+        Methods::COMPLETION_COMPLETE => ->(_) {},
         Methods::LOGGING_SET_LEVEL => ->(_) {},
       }
     end

--- a/test/model_context_protocol/methods_test.rb
+++ b/test/model_context_protocol/methods_test.rb
@@ -19,6 +19,13 @@ module ModelContextProtocol
       assert_equal "Server does not support sampling (required for sampling/createMessage)", error.message
     end
 
+    test "ensure_capability! for completion/complete raises an error if completions capability is not present" do
+      error = assert_raises(Methods::MissingRequiredCapabilityError) do
+        Methods.ensure_capability!(Methods::COMPLETION_COMPLETE, {})
+      end
+      assert_equal "Server does not support completions (required for completion/complete)", error.message
+    end
+
     test "ensure_capability! for logging/setLevel raises an error if logging capability is not present" do
       error = assert_raises(Methods::MissingRequiredCapabilityError) do
         Methods.ensure_capability!(Methods::LOGGING_SET_LEVEL, {})


### PR DESCRIPTION
## Motivation and Context

This PR fixes incorrect capabilities handling for `completion/complete`. As specified, the capability of `completion/complete` is `completions`, not `prompts`:
https://modelcontextprotocol.io/specification/2025-03-26/server/utilities/completion#capabilities

Note that in the Ruby SDK, `completion/complete`, like `logging/setLevel`, is not yet implemented. Therefore, an empty implementation has been added to server.rb.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
