### PR TITLE
Update gemspec to reflect `mcp` naming

### DIFF
--- a/.cursor/rules/release-changelogs.mdc
+++ b/.cursor/rules/release-changelogs.mdc
@@ -1,23 +1,20 @@
 ---
 description: writing changelog markdown when cutting a new release of the gem
-globs: 
+globs:
 alwaysApply: false
 ---
-- output the changelog as markdown when asked. 
+- output the changelog as markdown when asked.
 - git tags are used to mark the commit that cut a new release of the gem
-- the gem version is located in [version.rb](mdc:lib/model_context_protocol/version.rb)
+- the gem version is located in [version.rb](mdc:lib/mcp/version.rb)
 - use the git history, especially merge commits from PRs to construct the changelog
-- when necessary, look at the diff of files changed to determine whether a PR should be listed in 
+- when necessary, look at the diff of files changed to determine whether a PR should be listed in
   - ## Added; adds new functionality
   - ## Changed; alters functionality; especially backward compatible changes
-  - ## Fixed; bugfixes that are forward compatible 
+  - ## Fixed; bugfixes that are forward compatible
 
 use the following format for changelogs:
 
-https://cloudsmith.io/~shopify/repos/gems/packages/detail/ruby/mcp-ruby/{gem version}/
-
-# Changelog
-
+```
 ## Added
 - New functionality added that was not present before
 
@@ -25,8 +22,9 @@ https://cloudsmith.io/~shopify/repos/gems/packages/detail/ruby/mcp-ruby/{gem ver
 - Alterations to functionality that may indicate breaking changes
 
 ## Fixed
-- Bug fixes 
+- Bug fixes
 
 #### Full change list:
-- [Name of the PR #123](mdc:https:/github.com/Shopify/mcp-ruby/pull/123) @github-author-username 
-- [Name of the PR #456](mdc:https:/github.com/Shopify/mcp-ruby/pull/456) @another-github-author 
+- [Name of the PR #123](https:/github.com/modelcontextprotocol/ruby-sdk/pull/123) @github-author-username
+- [Name of the PR #456](https:/github.com/modelcontextprotocol/ruby-sdk/pull/456) @another-github-author
+```

--- a/examples/stdio_server.rb
+++ b/examples/stdio_server.rb
@@ -2,8 +2,8 @@
 # frozen_string_literal: true
 
 $LOAD_PATH.unshift(File.expand_path("../lib", __dir__))
-require "model_context_protocol"
-require "model_context_protocol/transports/stdio"
+require "mcp"
+require "mcp/transports/stdio"
 
 # Create a simple tool
 class ExampleTool < MCP::Tool

--- a/lib/mcp-ruby.rb
+++ b/lib/mcp-ruby.rb
@@ -1,3 +1,0 @@
-# frozen_string_literal: true
-
-require_relative "model_context_protocol"

--- a/lib/mcp.rb
+++ b/lib/mcp.rb
@@ -1,22 +1,23 @@
 # frozen_string_literal: true
 
 require_relative "mcp/server"
-require_relative "model_context_protocol/string_utils"
-require_relative "model_context_protocol/tool"
-require_relative "model_context_protocol/tool/input_schema"
-require_relative "model_context_protocol/tool/annotations"
-require_relative "model_context_protocol/tool/response"
-require_relative "model_context_protocol/content"
-require_relative "model_context_protocol/resource"
-require_relative "model_context_protocol/resource/contents"
-require_relative "model_context_protocol/resource/embedded"
-require_relative "model_context_protocol/resource_template"
-require_relative "model_context_protocol/prompt"
-require_relative "model_context_protocol/prompt/argument"
-require_relative "model_context_protocol/prompt/message"
-require_relative "model_context_protocol/prompt/result"
-require_relative "model_context_protocol/version"
-require_relative "model_context_protocol/configuration"
+require_relative "mcp/string_utils"
+require_relative "mcp/tool"
+require_relative "mcp/tool/input_schema"
+require_relative "mcp/tool/annotations"
+require_relative "mcp/tool/response"
+require_relative "mcp/content"
+require_relative "mcp/resource"
+require_relative "mcp/resource/contents"
+require_relative "mcp/resource/embedded"
+require_relative "mcp/resource_template"
+require_relative "mcp/prompt"
+require_relative "mcp/prompt/argument"
+require_relative "mcp/prompt/message"
+require_relative "mcp/prompt/result"
+require_relative "mcp/version"
+require_relative "mcp/configuration"
+require_relative "mcp/methods"
 
 module MCP
   class << self
@@ -38,5 +39,3 @@ module MCP
     end
   end
 end
-
-ModelContextProtocol = MCP

--- a/lib/mcp.rb
+++ b/lib/mcp.rb
@@ -1,7 +1,6 @@
-# typed: strict
 # frozen_string_literal: true
 
-require_relative "model_context_protocol/server"
+require_relative "mcp/server"
 require_relative "model_context_protocol/string_utils"
 require_relative "model_context_protocol/tool"
 require_relative "model_context_protocol/tool/input_schema"
@@ -19,7 +18,7 @@ require_relative "model_context_protocol/prompt/result"
 require_relative "model_context_protocol/version"
 require_relative "model_context_protocol/configuration"
 
-module ModelContextProtocol
+module MCP
   class << self
     def configure
       yield(configuration)
@@ -40,4 +39,4 @@ module ModelContextProtocol
   end
 end
 
-MCP = ModelContextProtocol
+ModelContextProtocol = MCP

--- a/lib/mcp/configuration.rb
+++ b/lib/mcp/configuration.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module ModelContextProtocol
+module MCP
   class Configuration
     DEFAULT_PROTOCOL_VERSION = "2024-11-05"
 

--- a/lib/mcp/content.rb
+++ b/lib/mcp/content.rb
@@ -1,7 +1,7 @@
 # typed: true
 # frozen_string_literal: true
 
-module ModelContextProtocol
+module MCP
   module Content
     class Text
       attr_reader :text, :annotations

--- a/lib/mcp/instrumentation.rb
+++ b/lib/mcp/instrumentation.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module ModelContextProtocol
+module MCP
   module Instrumentation
     def instrument_call(method, &block)
       start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)

--- a/lib/mcp/methods.rb
+++ b/lib/mcp/methods.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module ModelContextProtocol
+module MCP
   module Methods
     INITIALIZE = "initialize"
     PING = "ping"

--- a/lib/mcp/prompt.rb
+++ b/lib/mcp/prompt.rb
@@ -1,7 +1,7 @@
 # typed: strict
 # frozen_string_literal: true
 
-module ModelContextProtocol
+module MCP
   class Prompt
     class << self
       NOT_SET = Object.new
@@ -67,7 +67,7 @@ module ModelContextProtocol
         missing = required_args - args.keys
         return if missing.empty?
 
-        raise ModelContextProtocol::Server::RequestHandlerError.new(
+        raise MCP::Server::RequestHandlerError.new(
           "Missing required arguments: #{missing.join(", ")}", nil, error_type: :missing_required_arguments
         )
       end

--- a/lib/mcp/prompt/argument.rb
+++ b/lib/mcp/prompt/argument.rb
@@ -1,7 +1,7 @@
 # typed: strict
 # frozen_string_literal: true
 
-module ModelContextProtocol
+module MCP
   class Prompt
     class Argument
       attr_reader :name, :description, :required, :arguments

--- a/lib/mcp/prompt/message.rb
+++ b/lib/mcp/prompt/message.rb
@@ -1,7 +1,7 @@
 # typed: strict
 # frozen_string_literal: true
 
-module ModelContextProtocol
+module MCP
   class Prompt
     class Message
       attr_reader :role, :content

--- a/lib/mcp/prompt/result.rb
+++ b/lib/mcp/prompt/result.rb
@@ -1,7 +1,7 @@
 # typed: strict
 # frozen_string_literal: true
 
-module ModelContextProtocol
+module MCP
   class Prompt
     class Result
       attr_reader :description, :messages

--- a/lib/mcp/resource.rb
+++ b/lib/mcp/resource.rb
@@ -1,7 +1,7 @@
 # typed: strict
 # frozen_string_literal: true
 
-module ModelContextProtocol
+module MCP
   class Resource
     attr_reader :uri, :name, :description, :mime_type
 

--- a/lib/mcp/resource/contents.rb
+++ b/lib/mcp/resource/contents.rb
@@ -1,7 +1,7 @@
 # typed: strict
 # frozen_string_literal: true
 
-module ModelContextProtocol
+module MCP
   class Resource
     class Contents
       attr_reader :uri, :mime_type

--- a/lib/mcp/resource/embedded.rb
+++ b/lib/mcp/resource/embedded.rb
@@ -1,7 +1,7 @@
 # typed: strict
 # frozen_string_literal: true
 
-module ModelContextProtocol
+module MCP
   class Resource
     class Embedded
       attr_reader :resource, :annotations

--- a/lib/mcp/resource_template.rb
+++ b/lib/mcp/resource_template.rb
@@ -1,7 +1,7 @@
 # typed: strict
 # frozen_string_literal: true
 
-module ModelContextProtocol
+module MCP
   class ResourceTemplate
     attr_reader :uri_template, :name, :description, :mime_type
 

--- a/lib/mcp/server.rb
+++ b/lib/mcp/server.rb
@@ -4,7 +4,7 @@ require "json_rpc_handler"
 require_relative "instrumentation"
 require_relative "methods"
 
-module ModelContextProtocol
+module MCP
   class Server
     DEFAULT_VERSION = "0.1.0"
 
@@ -44,7 +44,7 @@ module ModelContextProtocol
       @resource_templates = resource_templates
       @resource_index = index_resources_by_uri(resources)
       @server_context = server_context
-      @configuration = ModelContextProtocol.configuration.merge(configuration)
+      @configuration = MCP.configuration.merge(configuration)
 
       @handlers = {
         Methods::RESOURCES_LIST => method(:list_resources),

--- a/lib/mcp/string_utils.rb
+++ b/lib/mcp/string_utils.rb
@@ -1,7 +1,7 @@
 # typed: strict
 # frozen_string_literal: true
 
-module ModelContextProtocol
+module MCP
   module StringUtils
     extend self
 

--- a/lib/mcp/tool.rb
+++ b/lib/mcp/tool.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module ModelContextProtocol
+module MCP
   class Tool
     class << self
       NOT_SET = Object.new

--- a/lib/mcp/tool/annotations.rb
+++ b/lib/mcp/tool/annotations.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module ModelContextProtocol
+module MCP
   class Tool
     class Annotations
       attr_reader :title, :read_only_hint, :destructive_hint, :idempotent_hint, :open_world_hint

--- a/lib/mcp/tool/input_schema.rb
+++ b/lib/mcp/tool/input_schema.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module ModelContextProtocol
+module MCP
   class Tool
     class InputSchema
       attr_reader :properties, :required

--- a/lib/mcp/tool/response.rb
+++ b/lib/mcp/tool/response.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module ModelContextProtocol
+module MCP
   class Tool
     class Response
       attr_reader :content, :is_error

--- a/lib/mcp/transport.rb
+++ b/lib/mcp/transport.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module ModelContextProtocol
+module MCP
   class Transport
     def initialize(server)
       @server = server

--- a/lib/mcp/transports/stdio.rb
+++ b/lib/mcp/transports/stdio.rb
@@ -3,7 +3,7 @@
 require_relative "../transport"
 require "json"
 
-module ModelContextProtocol
+module MCP
   module Transports
     class StdioTransport < Transport
       def initialize(server)

--- a/lib/mcp/version.rb
+++ b/lib/mcp/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-module ModelContextProtocol
+module MCP
   VERSION = "0.7.0"
 end

--- a/mcp.gemspec
+++ b/mcp.gemspec
@@ -3,7 +3,7 @@
 require_relative "lib/model_context_protocol/version"
 
 Gem::Specification.new do |spec|
-  spec.name          = "model_context_protocol"
+  spec.name          = "mcp"
   spec.version       = ModelContextProtocol::VERSION
   spec.authors       = ["Model Context Protocol"]
   spec.email         = ["mcp-support@anthropic.com"]

--- a/mcp.gemspec
+++ b/mcp.gemspec
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-require_relative "lib/model_context_protocol/version"
+require_relative "lib/mcp/version"
 
 Gem::Specification.new do |spec|
   spec.name          = "mcp"
-  spec.version       = ModelContextProtocol::VERSION
+  spec.version       = MCP::VERSION
   spec.authors       = ["Model Context Protocol"]
   spec.email         = ["mcp-support@anthropic.com"]
 

--- a/test/model_context_protocol/configuration_test.rb
+++ b/test/model_context_protocol/configuration_test.rb
@@ -2,7 +2,7 @@
 
 require "test_helper"
 
-module ModelContextProtocol
+module MCP
   class ConfigurationTest < ActiveSupport::TestCase
     test "initializes with a default no-op exception reporter" do
       config = Configuration.new

--- a/test/model_context_protocol/instrumentation_test.rb
+++ b/test/model_context_protocol/instrumentation_test.rb
@@ -2,14 +2,14 @@
 
 require "test_helper"
 
-module ModelContextProtocol
+module MCP
   class InstrumentationTest < ActiveSupport::TestCase
     class Subject
       include Instrumentation
       attr_reader :instrumentation_data_received, :configuration
 
       def initialize
-        @configuration = ModelContextProtocol::Configuration.new
+        @configuration = MCP::Configuration.new
         @configuration.instrumentation_callback = ->(data) { @instrumentation_data_received = data }
       end
 

--- a/test/model_context_protocol/methods_test.rb
+++ b/test/model_context_protocol/methods_test.rb
@@ -3,7 +3,7 @@
 
 require "test_helper"
 
-module ModelContextProtocol
+module MCP
   class MethodsTest < ActiveSupport::TestCase
     test "ensure_capability! for tools/list method raises an error if tools capability is not present" do
       error = assert_raises(Methods::MissingRequiredCapabilityError) do

--- a/test/model_context_protocol/prompt_test.rb
+++ b/test/model_context_protocol/prompt_test.rb
@@ -3,7 +3,7 @@
 
 require "test_helper"
 
-module ModelContextProtocol
+module MCP
   class PromptTest < ActiveSupport::TestCase
     class TestPrompt < Prompt
       description "Test prompt"

--- a/test/model_context_protocol/server_test.rb
+++ b/test/model_context_protocol/server_test.rb
@@ -5,7 +5,7 @@ require "test_helper"
 require "json"
 require "debug"
 
-module ModelContextProtocol
+module MCP
   class ServerTest < ActiveSupport::TestCase
     include InstrumentationTestHelper
     setup do
@@ -47,7 +47,7 @@ module ModelContextProtocol
       )
 
       @server_name = "test_server"
-      configuration = ModelContextProtocol::Configuration.new
+      configuration = MCP::Configuration.new
       configuration.instrumentation_callback = instrumentation_helper.callback
 
       @server = Server.new(
@@ -61,7 +61,7 @@ module ModelContextProtocol
       )
     end
 
-    # https://spec.modelcontextprotocol.io/specification/2025-03-26/basic/utilities/ping/#behavior-requirements
+    # https://spec.MCP.io/specification/2025-03-26/basic/utilities/ping/#behavior-requirements
     test "#handle ping request returns empty response" do
       request = {
         jsonrpc: "2.0",
@@ -655,14 +655,14 @@ module ModelContextProtocol
 
     test "the global configuration is used if no configuration is passed to the server" do
       server = Server.new(name: "test_server")
-      assert_equal ModelContextProtocol.configuration.instrumentation_callback,
+      assert_equal MCP.configuration.instrumentation_callback,
         server.configuration.instrumentation_callback
-      assert_equal ModelContextProtocol.configuration.exception_reporter,
+      assert_equal MCP.configuration.exception_reporter,
         server.configuration.exception_reporter
     end
 
     test "the server configuration takes precedence over the global configuration" do
-      configuration = ModelContextProtocol::Configuration.new
+      configuration = MCP::Configuration.new
       local_callback = ->(data) { puts "Local callback #{data.inspect}" }
       local_exception_reporter = ->(exception, server_context) {
         puts "Local exception reporter #{exception.inspect} #{server_context.inspect}"

--- a/test/model_context_protocol/string_utils_test.rb
+++ b/test/model_context_protocol/string_utils_test.rb
@@ -2,7 +2,7 @@
 
 require "test_helper"
 
-module ModelContextProtocol
+module MCP
   class StringUtilsTest < Minitest::Test
     def test_handle_from_class_name_returns_the_class_name_without_the_module_for_a_class_without_a_module
       assert_equal("test", StringUtils.handle_from_class_name("Test"))

--- a/test/model_context_protocol/tool/input_schema_test.rb
+++ b/test/model_context_protocol/tool/input_schema_test.rb
@@ -2,7 +2,7 @@
 
 require "test_helper"
 
-module ModelContextProtocol
+module MCP
   class Tool
     class InputSchemaTest < ActiveSupport::TestCase
       test "required arguments are converted to symbols" do

--- a/test/model_context_protocol/tool_test.rb
+++ b/test/model_context_protocol/tool_test.rb
@@ -3,7 +3,7 @@
 
 require "test_helper"
 
-module ModelContextProtocol
+module MCP
   class ToolTest < ActiveSupport::TestCase
     class TestTool < Tool
       tool_name "test_tool"

--- a/test/model_context_protocol/transports/stdio_transport_test.rb
+++ b/test/model_context_protocol/transports/stdio_transport_test.rb
@@ -1,16 +1,16 @@
 # frozen_string_literal: true
 
 require "test_helper"
-require "model_context_protocol/transports/stdio"
+require "mcp/transports/stdio"
 require "json"
 
-module ModelContextProtocol
+module MCP
   module Transports
     class StdioTransportTest < ActiveSupport::TestCase
       include InstrumentationTestHelper
 
       setup do
-        configuration = ModelContextProtocol::Configuration.new
+        configuration = MCP::Configuration.new
         configuration.instrumentation_callback = instrumentation_helper.callback
         @server = Server.new(name: "test_server", configuration: configuration)
         @transport = StdioTransport.new(@server)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,7 +3,7 @@
 ENV["RAILS_ENV"] ||= "test"
 
 require "bundler/setup"
-require "model_context_protocol"
+require "mcp"
 
 require "minitest/autorun"
 require "minitest/reporters"


### PR DESCRIPTION
## Motivation and Context

the gem will be published to RubyGems under https://rubygems.org/gems/mcp as `mcp`, so gemspec, lib structure and naming should reflect this.

## How Has This Been Tested?

moved files, renamed constants, ran tests; CI is green

## Breaking Changes
none. `ModelContextProtocol` is aliased to `MCP` to allow backward compatibility if the gem has been leveraged using git instead of RubyGems by intrepid users.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
n/a

