### PR TITLE
Enable RuboCop on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,3 +22,14 @@ jobs:
         run: bundle install
       - run: bundle exec rake test
         continue-on-error: ${{ matrix.entry.allowed-failure }}
+
+  rubocop:
+    runs-on: ubuntu-latest
+    name: RuboCop
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.2 # Specify the oldest supported Ruby version.
+          bundler-cache: true
+      - run: bundle exec rake rubocop


### PR DESCRIPTION
## Motivation and Context

When running `bundle exec rake` in the local environment, RuboCop is executed, but it was not included in the CI workflow.

This PR enables RuboCop execution in the CI workflow. RuboCop performs static analysis on the source code using Ruby 3.2, in accordance with the gemspec setting `spec.required_ruby_version = ">= 3.2.0"`: https://github.com/modelcontextprotocol/ruby-sdk/blob/6b49222edb8709821a58bbe39cb85fd5409882eb/model_context_protocol.gemspec#L16

In other words, it is not necessary to run RuboCop under every Ruby version from 3.2 to head, so it is defined as a separate job from the test job.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
