### PR TITLE
Enable RuboCop Minitest and RuboCop Rake for development

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,10 @@
 inherit_gem:
   rubocop-shopify: rubocop.yml
+
+plugins:
+  - rubocop-minitest
+  - rubocop-rake
+
 Naming/FileName:
   Exclude:
     - 'lib/mcp-ruby.rb'

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,8 @@ gemspec
 # Specify development dependencies below
 gem "minitest", "~> 5.1", require: false
 gem "rake", "~> 13.0"
+gem "rubocop-minitest"
+gem "rubocop-rake"
 gem "rubocop-shopify", require: false
 
 gem "minitest-reporters"

--- a/test/model_context_protocol/prompt_test.rb
+++ b/test/model_context_protocol/prompt_test.rb
@@ -67,7 +67,7 @@ module ModelContextProtocol
       assert_equal "a mock prompt for testing", prompt.description
       assert_equal "test_argument", prompt.arguments.first.name
       assert_equal "Test argument", prompt.arguments.first.description
-      assert_equal true, prompt.arguments.first.required
+      assert prompt.arguments.first.required
 
       expected_template_result = {
         description: "Hello, world!",

--- a/test/model_context_protocol/server_test.rb
+++ b/test/model_context_protocol/server_test.rb
@@ -153,7 +153,7 @@ module ModelContextProtocol
       assert_kind_of Array, result[:tools]
       assert_equal "test_tool", result[:tools][0][:name]
       assert_equal "Test tool", result[:tools][0][:description]
-      assert_equal({}, result[:tools][0][:inputSchema])
+      assert_empty(result[:tools][0][:inputSchema])
       assert_instrumentation_data({ method: "tools/list" })
     end
 

--- a/test/model_context_protocol/tool/input_schema_test.rb
+++ b/test/model_context_protocol/tool/input_schema_test.rb
@@ -25,7 +25,7 @@ module ModelContextProtocol
 
       test "missing_required_arguments returns an empty array if no required arguments are missing" do
         input_schema = InputSchema.new(properties: { message: { type: "string" } }, required: [:message])
-        assert_equal [], input_schema.missing_required_arguments({ message: "Hello, world!" })
+        assert_empty input_schema.missing_required_arguments({ message: "Hello, world!" })
       end
     end
   end

--- a/test/model_context_protocol/transports/stdio_transport_test.rb
+++ b/test/model_context_protocol/transports/stdio_transport_test.rb
@@ -46,7 +46,7 @@ module ModelContextProtocol
           response = JSON.parse(output.string, symbolize_names: true)
           assert_equal("2.0", response[:jsonrpc])
           assert_equal("123", response[:id])
-          assert_equal({}, response[:result])
+          assert_empty(response[:result])
           refute(@transport.instance_variable_get(:@open))
         ensure
           $stdin = original_stdin


### PR DESCRIPTION
## Motivation and Context

Based on the following information, `rubocop-minitest` and `rubocop-rake` have been added for development. Autocorrection has been applied for offenses detected by `rubocop-minitest`.

```console
$ bundle exec rake
(snip)

Running RuboCop...
Inspecting 40 files
........................................

40 files inspected, no offenses detected

Tip: Based on detected gems, the following RuboCop extension libraries might be helpful:
* rubocop-minitest (https://rubygems.org/gems/rubocop-minitest)
* rubocop-rake (https://rubygems.org/gems/rubocop-rake)

You can opt out of this message by adding the following to your config
(see https://docs.rubocop.org/rubocop/extensions.html#extension-suggestions for more options):
AllCops:
    SuggestExtensions: false
```

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

This is a proposal intended to illustrate the code changes that would result from enabling the cop.
If preserving the existing behavior is preferred, it is also possible to set `SuggestExtensions: false` instead.

