### PR TITLE
Fix an error when using `bin/console`

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 require "bundler/setup"
-require "model_context_protocol"
+require "mcp"
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.


### PR DESCRIPTION
## Motivation and Context

Follow-up to #24.

This PR fixes the following error when using `bin/console`:

```console
$ bin/console
/Users/koic/.rbenv/versions/3.4.4/lib/ruby/3.4.0/bundled_gems.rb:82:
in 'Kernel.require': cannot load such file -- model_context_protocol (LoadError)
from /Users/koic/.rbenv/versions/3.4.4/lib/ruby/3.4.0/bundled_gems.rb:82:
in 'block (2 levels) in Kernel#replace_require'
        from bin/console:5:in '<main>'
```

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
