### PR TITLE
Make `description` and `mime_type` optional keyword arguments in `Resource`

### DIFF
--- a/lib/mcp/resource.rb
+++ b/lib/mcp/resource.rb
@@ -5,7 +5,7 @@ module MCP
   class Resource
     attr_reader :uri, :name, :description, :mime_type
 
-    def initialize(uri:, name:, description:, mime_type:)
+    def initialize(uri:, name:, description: nil, mime_type: nil)
       @uri = uri
       @name = name
       @description = description


### PR DESCRIPTION
## Motivation and Context

This change is related to #29.

According to the specification, both `description` and `mimeType` of Resource are optional: https://modelcontextprotocol.io/specification/2025-03-26/server/resources#resource

Therefore, it makes sense to treat them as optional keyword arguments, similar to how this is done in `ResourceTemplate`: https://github.com/modelcontextprotocol/ruby-sdk/blob/0b49c3/lib/mcp/resource_template.rb#L8

As additional context, the TypeScript SDK also treats them as optional. https://github.com/modelcontextprotocol/typescript-sdk/blob/1.12.1/src/types.ts#L438-L466

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
