### PR TITLE
Remove unused config from .rubocop.yml

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,3 @@ inherit_gem:
 plugins:
   - rubocop-minitest
   - rubocop-rake
-
-Naming/FileName:
-  Exclude:
-    - 'lib/mcp-ruby.rb'


### PR DESCRIPTION
## Motivation and Context

Follow-up to #24.

lib/mcp-ruby.rb was removed in https://github.com/modelcontextprotocol/ruby-sdk/pull/24.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
