### PR TITLE
Validate ToolCall Args against Schema

### DIFF
--- a/lib/mcp/configuration.rb
+++ b/lib/mcp/configuration.rb
@@ -4,12 +4,18 @@ module MCP
   class Configuration
     DEFAULT_PROTOCOL_VERSION = "2024-11-05"
 
-    attr_writer :exception_reporter, :instrumentation_callback, :protocol_version
+    attr_writer :exception_reporter, :instrumentation_callback, :protocol_version, :validate_tool_call_arguments
 
-    def initialize(exception_reporter: nil, instrumentation_callback: nil, protocol_version: nil)
+    def initialize(exception_reporter: nil, instrumentation_callback: nil, protocol_version: nil,
+      validate_tool_call_arguments: true)
       @exception_reporter = exception_reporter
       @instrumentation_callback = instrumentation_callback
       @protocol_version = protocol_version
+      unless validate_tool_call_arguments.is_a?(TrueClass) || validate_tool_call_arguments.is_a?(FalseClass)
+        raise ArgumentError, "validate_tool_call_arguments must be a boolean"
+      end
+
+      @validate_tool_call_arguments = validate_tool_call_arguments
     end
 
     def protocol_version
@@ -36,6 +42,12 @@ module MCP
       !@instrumentation_callback.nil?
     end
 
+    attr_reader :validate_tool_call_arguments
+
+    def validate_tool_call_arguments?
+      !!@validate_tool_call_arguments
+    end
+
     def merge(other)
       return self if other.nil?
 
@@ -54,11 +66,13 @@ module MCP
       else
         @protocol_version
       end
+      validate_tool_call_arguments = other.validate_tool_call_arguments
 
       Configuration.new(
         exception_reporter:,
         instrumentation_callback:,
         protocol_version:,
+        validate_tool_call_arguments:,
       )
     end
 

--- a/lib/mcp/tool/input_schema.rb
+++ b/lib/mcp/tool/input_schema.rb
@@ -1,13 +1,18 @@
 # frozen_string_literal: true
 
+require "json-schema"
+
 module MCP
   class Tool
     class InputSchema
+      class ValidationError < StandardError; end
+
       attr_reader :properties, :required
 
       def initialize(properties: {}, required: [])
         @properties = properties
         @required = required.map(&:to_sym)
+        validate_schema!
       end
 
       def to_h
@@ -20,6 +25,32 @@ module MCP
 
       def missing_required_arguments(arguments)
         (required - arguments.keys.map(&:to_sym))
+      end
+
+      def validate_arguments(arguments)
+        errors = JSON::Validator.fully_validate(to_h, arguments)
+        if errors.any?
+          raise ValidationError, "Invalid arguments: #{errors.join(", ")}"
+        end
+      end
+
+      private
+
+      def validate_schema!
+        schema = to_h
+        begin
+          schema_reader = JSON::Schema::Reader.new(
+            accept_uri: false,
+            accept_file: ->(path) { path.to_s.start_with?(Gem.loaded_specs["json-schema"].full_gem_path) },
+          )
+          metaschema = JSON::Validator.validator_for_name("draft4").metaschema
+          errors = JSON::Validator.fully_validate(metaschema, schema, schema_reader: schema_reader)
+          if errors.any?
+            raise ArgumentError, "Invalid JSON Schema: #{errors.join(", ")}"
+          end
+        rescue StandardError => e
+          raise ArgumentError, "Invalid JSON Schema: #{e.message}"
+        end
       end
     end
   end

--- a/mcp.gemspec
+++ b/mcp.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency("json_rpc_handler", "~> 0.1")
+  spec.add_dependency("json-schema", "~> 4.1")
   spec.add_development_dependency("activesupport")
   spec.add_development_dependency("sorbet-static-and-runtime")
 end

--- a/test/mcp/configuration_test.rb
+++ b/test/mcp/configuration_test.rb
@@ -61,5 +61,45 @@ module MCP
       merged = config3.merge(config1)
       assert_equal "2025-03-27", merged.protocol_version
     end
+
+    test "defaults validate_tool_call_arguments to true" do
+      config = Configuration.new
+      assert config.validate_tool_call_arguments
+    end
+
+    test "can set validate_tool_call_arguments to false" do
+      config = Configuration.new(validate_tool_call_arguments: false)
+      refute config.validate_tool_call_arguments
+    end
+
+    test "validate_tool_call_arguments? returns false when set" do
+      config = Configuration.new(validate_tool_call_arguments: false)
+      refute config.validate_tool_call_arguments?
+    end
+
+    test "validate_tool_call_arguments? returns true when not set" do
+      config = Configuration.new
+      assert config.validate_tool_call_arguments?
+    end
+
+    test "merge preserves validate_tool_call_arguments from other config" do
+      config1 = Configuration.new(validate_tool_call_arguments: false)
+      config2 = Configuration.new
+      merged = config1.merge(config2)
+      assert merged.validate_tool_call_arguments?
+    end
+
+    test "merge preserves validate_tool_call_arguments from self when other not set" do
+      config1 = Configuration.new(validate_tool_call_arguments: false)
+      config2 = Configuration.new
+      merged = config2.merge(config1)
+      refute merged.validate_tool_call_arguments
+    end
+
+    test "raises ArgumentError when validate_tool_call_arguments is not a boolean" do
+      assert_raises(ArgumentError) do
+        Configuration.new(validate_tool_call_arguments: "true")
+      end
+    end
   end
 end

--- a/test/mcp/tool/input_schema_test.rb
+++ b/test/mcp/tool/input_schema_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "mcp/tool/input_schema"
 
 module MCP
   class Tool
@@ -26,6 +27,29 @@ module MCP
       test "missing_required_arguments returns an empty array if no required arguments are missing" do
         input_schema = InputSchema.new(properties: { message: { type: "string" } }, required: [:message])
         assert_empty input_schema.missing_required_arguments({ message: "Hello, world!" })
+      end
+
+      test "valid schema initialization" do
+        schema = InputSchema.new(properties: { foo: { type: "string" } }, required: [:foo])
+        assert_equal({ type: "object", properties: { foo: { type: "string" } }, required: [:foo] }, schema.to_h)
+      end
+
+      test "invalid schema raises argument error" do
+        assert_raises(ArgumentError) do
+          InputSchema.new(properties: { foo: { type: "invalid_type" } }, required: [:foo])
+        end
+      end
+
+      test "validate arguments with valid data" do
+        schema = InputSchema.new(properties: { foo: { type: "string" } }, required: [:foo])
+        assert_nil(schema.validate_arguments({ foo: "bar" }))
+      end
+
+      test "validate arguments with invalid data" do
+        schema = InputSchema.new(properties: { foo: { type: "string" } }, required: [:foo])
+        assert_raises(InputSchema::ValidationError) do
+          schema.validate_arguments({ foo: 123 })
+        end
       end
     end
   end

--- a/test/mcp/tool_test.rb
+++ b/test/mcp/tool_test.rb
@@ -82,6 +82,23 @@ module MCP
       assert_equal expected, tool.input_schema.to_h
     end
 
+    test "raises detailed error message for invalid schema" do
+      error = assert_raises(ArgumentError) do
+        Class.new(MCP::Tool) do
+          input_schema(
+            properties: {
+              count: { type: "integer", minimum: "not a number" },
+            },
+            required: [:count],
+          )
+        end
+      end
+
+      assert_includes error.message, "Invalid JSON Schema"
+      assert_includes error.message, "#/properties/count/minimum"
+      assert_includes error.message, "string did not match the following type: number"
+    end
+
     test ".define allows definition of simple tools with a block" do
       tool = Tool.define(name: "mock_tool", description: "a mock tool for testing") do |_|
         Tool::Response.new([{ type: "text", content: "OK" }])
@@ -225,6 +242,24 @@ module MCP
       response = tool.call(message: "test")
       assert_equal response.content, [{ type: "text", content: "OK" }]
       assert_equal response.is_error, false
+    end
+
+    test "input_schema rejects any $ref in schema" do
+      schema_with_ref = {
+        properties: {
+          foo: { "$ref" => "#/definitions/bar" },
+        },
+        required: [],
+        definitions: {
+          bar: { type: "string" },
+        },
+      }
+      error = assert_raises(ArgumentError) do
+        Class.new(MCP::Tool) do
+          input_schema schema_with_ref
+        end
+      end
+      assert_match(/Invalid JSON Schema/, error.message)
     end
   end
 end


### PR DESCRIPTION
## Motivation and Context
Tool call arguments are not being validated against the schema. This ensures that the schema is valid and that the tool call args are valid. Otherwise it fails early. 

There is an option to disable tool call validation.

## How Has This Been Tested?
Yes. Tested on internal products.

## Breaking Changes
Tool calls will be validated, if your application has tool calls coming in that don't match the schema these requests will now fail.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
