### PR TITLE
[Doc] Tweak an example for `MCP::Resource` in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,9 +460,10 @@ The `MCP::Resource` class provides a way to register resources with the server.
 
 ```ruby
 resource = MCP::Resource.new(
-  uri: "example.com/my_resource",
-  mime_type: "text/plain",
-  text: "Lorem ipsum dolor sit amet"
+  uri: "https://example.com/my_resource",
+  name: "My Resource",
+  description: "Lorem ipsum dolor sit amet",
+  mime_type: "text/html",
 )
 
 server = MCP::Server.new(
@@ -478,13 +479,13 @@ server.resources_read_handler do |params|
   [{
     uri: params[:uri],
     mimeType: "text/plain",
-    text: "Hello, world!",
+    text: params[:uri],
   }]
 end
 
 ```
 
-otherwise 'resources/read' requests will be a no-op.
+otherwise `resources/read` requests will be a no-op.
 
 ## Releases
 


### PR DESCRIPTION
## Motivation and Context

`MCP::Resource` doesn't have `text` attribute:
https://github.com/modelcontextprotocol/ruby-sdk/blob/v0.1.0/lib/mcp/resource.rb#L8-L13

I've replaced it with attributes that it actually supports.

Also, the use of `text: "Hello, world!"` in the example of `server.resources_read_handler` implementation resulted in an unexpected response the first time I worked with `Resource`. While it may not be the best (but better), in my experience using Resources with Cline, `text: params[:uri]` served as a clearer response when interacting with an LLM, making it easier to understand.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
