### PR TITLE
Extend modules instead of inheriting classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,9 @@ require "mcp"
 require "mcp/server/transports/stdio_transport"
 
 # Create a simple tool
-class ExampleTool < MCP::Tool
+module ExampleTool
+  extend MCP::Tool
+
   description "A simple example tool that echoes back its arguments"
   input_schema(
     properties: {
@@ -275,7 +277,9 @@ This gem provides a `MCP::Tool` class that can be used to create tools in two wa
 1. As a class definition:
 
 ```ruby
-class MyTool < MCP::Tool
+module MyTool
+  extend MCP::Tool
+
   description "This tool performs specific functionality..."
   input_schema(
     properties: {
@@ -338,7 +342,9 @@ The `MCP::Prompt` class provides two ways to create prompts:
 1. As a class definition with metadata:
 
 ```ruby
-class MyPrompt < MCP::Prompt
+module MyPrompt
+  extend MCP::Prompt
+
   prompt_name "my_prompt"  # Optional - defaults to underscored class name
   description "This prompt performs specific functionality..."
   arguments [

--- a/lib/mcp/prompt/argument.rb
+++ b/lib/mcp/prompt/argument.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 module MCP
-  class Prompt
+  module Prompt
     class Argument
       attr_reader :name, :description, :required, :arguments
 

--- a/lib/mcp/prompt/message.rb
+++ b/lib/mcp/prompt/message.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 module MCP
-  class Prompt
+  module Prompt
     class Message
       attr_reader :role, :content
 

--- a/lib/mcp/prompt/result.rb
+++ b/lib/mcp/prompt/result.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 module MCP
-  class Prompt
+  module Prompt
     class Result
       attr_reader :description, :messages
 

--- a/lib/mcp/tool.rb
+++ b/lib/mcp/tool.rb
@@ -1,84 +1,85 @@
 # frozen_string_literal: true
 
 module MCP
-  class Tool
+  module Tool
+    NOT_SET = Object.new
+
+    attr_reader :description_value
+    attr_reader :input_schema_value
+    attr_reader :annotations_value
+
     class << self
-      NOT_SET = Object.new
-
-      attr_reader :description_value
-      attr_reader :input_schema_value
-      attr_reader :annotations_value
-
-      def call(*args, server_context:)
-        raise NotImplementedError, "Subclasses must implement call"
-      end
-
-      def to_h
-        result = {
-          name: name_value,
-          description: description_value,
-          inputSchema: input_schema_value.to_h,
-        }
-        result[:annotations] = annotations_value.to_h if annotations_value
-        result
-      end
-
-      def inherited(subclass)
-        super
-        subclass.instance_variable_set(:@name_value, nil)
-        subclass.instance_variable_set(:@description_value, nil)
-        subclass.instance_variable_set(:@input_schema_value, nil)
-        subclass.instance_variable_set(:@annotations_value, nil)
-      end
-
-      def tool_name(value = NOT_SET)
-        if value == NOT_SET
-          name_value
-        else
-          @name_value = value
-        end
-      end
-
-      def name_value
-        @name_value || StringUtils.handle_from_class_name(name)
-      end
-
-      def description(value = NOT_SET)
-        if value == NOT_SET
-          @description_value
-        else
-          @description_value = value
-        end
-      end
-
-      def input_schema(value = NOT_SET)
-        if value == NOT_SET
-          input_schema_value
-        elsif value.is_a?(Hash)
-          properties = value[:properties] || value["properties"] || {}
-          required = value[:required] || value["required"] || []
-          @input_schema_value = InputSchema.new(properties:, required:)
-        elsif value.is_a?(InputSchema)
-          @input_schema_value = value
-        end
-      end
-
-      def annotations(hash = NOT_SET)
-        if hash == NOT_SET
-          @annotations_value
-        else
-          @annotations_value = Annotations.new(**hash)
-        end
-      end
-
       def define(name: nil, description: nil, input_schema: nil, annotations: nil, &block)
-        Class.new(self) do
+        Module.new do
+          extend Tool
           tool_name name
           description description
           input_schema input_schema
-          self.annotations(annotations) if annotations
+          annotations annotations if annotations
           define_singleton_method(:call, &block) if block
         end
+      end
+    end
+
+    def call(*args, server_context:)
+      raise NotImplementedError, "Tools must implement call"
+    end
+
+    def to_h
+      result = {
+        name: name_value,
+        description: description_value,
+        inputSchema: input_schema_value.to_h,
+      }
+      result[:annotations] = annotations_value.to_h if annotations_value
+      result
+    end
+
+    def extended(mod)
+      super
+      mod.instance_variable_set(:@name_value, nil)
+      mod.instance_variable_set(:@description_value, nil)
+      mod.instance_variable_set(:@input_schema_value, nil)
+      mod.instance_variable_set(:@annotations_value, nil)
+    end
+
+    def tool_name(value = NOT_SET)
+      if value == NOT_SET
+        name_value
+      else
+        @name_value = value
+      end
+    end
+
+    def name_value
+      @name_value || StringUtils.handle_from_class_name(name)
+    end
+
+    def description(value = NOT_SET)
+      if value == NOT_SET
+        @description_value
+      else
+        @description_value = value
+      end
+    end
+
+    def input_schema(value = NOT_SET)
+      if value == NOT_SET
+        input_schema_value
+      elsif value.is_a?(Hash)
+        properties = value[:properties] || value["properties"] || {}
+        required = value[:required] || value["required"] || []
+        @input_schema_value = InputSchema.new(properties:, required:)
+      elsif value.is_a?(InputSchema)
+        @input_schema_value = value
+      end
+    end
+
+    def annotations(hash = NOT_SET)
+      if hash == NOT_SET
+        @annotations_value
+      else
+        @annotations_value = Annotations.new(**hash)
       end
     end
   end

--- a/lib/mcp/tool/annotations.rb
+++ b/lib/mcp/tool/annotations.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module MCP
-  class Tool
+  module Tool
     class Annotations
       attr_reader :title, :read_only_hint, :destructive_hint, :idempotent_hint, :open_world_hint
 

--- a/lib/mcp/tool/input_schema.rb
+++ b/lib/mcp/tool/input_schema.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module MCP
-  class Tool
+  module Tool
     class InputSchema
       attr_reader :properties, :required
 

--- a/lib/mcp/tool/response.rb
+++ b/lib/mcp/tool/response.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module MCP
-  class Tool
+  module Tool
     class Response
       attr_reader :content, :is_error
 

--- a/test/mcp/prompt_test.rb
+++ b/test/mcp/prompt_test.rb
@@ -5,7 +5,9 @@ require "test_helper"
 
 module MCP
   class PromptTest < ActiveSupport::TestCase
-    class TestPrompt < Prompt
+    class TestPrompt
+      extend Prompt
+
       description "Test prompt"
       arguments [
         Prompt::Argument.new(name: "test_argument", description: "Test argument", required: true),
@@ -41,7 +43,9 @@ module MCP
     end
 
     test "allows declarative definition of prompts as classes" do
-      class MockPrompt < Prompt
+      class MockPrompt
+        extend Prompt
+
         prompt_name "my_mock_prompt"
         description "a mock prompt for testing"
         arguments [
@@ -82,7 +86,9 @@ module MCP
     end
 
     test "defaults to class name as prompt name" do
-      class DefaultNamePrompt < Prompt
+      class DefaultNamePrompt
+        extend Prompt
+
         description "a mock prompt for testing"
         arguments [
           Prompt::Argument.new(name: "test_argument", description: "Test argument", required: true),

--- a/test/mcp/server_test.rb
+++ b/test/mcp/server_test.rb
@@ -258,7 +258,9 @@ module MCP
     end
 
     test "#handle_json tools/call executes tool and returns result, when the tool is typed with Sorbet" do
-      class TypedTestTool < Tool
+      class TypedTestTool
+        extend Tool
+
         tool_name "test_tool"
         description "a test tool for testing"
         input_schema({ properties: { message: { type: "string" } }, required: ["message"] })

--- a/test/mcp/tool/input_schema_test.rb
+++ b/test/mcp/tool/input_schema_test.rb
@@ -3,7 +3,7 @@
 require "test_helper"
 
 module MCP
-  class Tool
+  module Tool
     class InputSchemaTest < ActiveSupport::TestCase
       test "required arguments are converted to symbols" do
         input_schema = InputSchema.new(properties: { message: { type: "string" } }, required: ["message"])

--- a/test/mcp/tool_test.rb
+++ b/test/mcp/tool_test.rb
@@ -5,7 +5,9 @@ require "test_helper"
 
 module MCP
   class ToolTest < ActiveSupport::TestCase
-    class TestTool < Tool
+    class TestTool
+      extend Tool
+
       tool_name "test_tool"
       description "a test tool for testing"
       input_schema({ properties: { message: { type: "string" } }, required: ["message"] })
@@ -49,7 +51,9 @@ module MCP
     end
 
     test "allows declarative definition of tools as classes" do
-      class MockTool < Tool
+      class MockTool
+        extend Tool
+
         tool_name "my_mock_tool"
         description "a mock tool for testing"
         input_schema({ properties: { message: { type: "string" } }, required: [:message] })
@@ -63,7 +67,8 @@ module MCP
     end
 
     test "defaults to class name as tool name" do
-      class DefaultNameTool < Tool
+      class DefaultNameTool
+        extend Tool
       end
 
       tool = DefaultNameTool
@@ -72,8 +77,10 @@ module MCP
     end
 
     test "accepts input schema as an InputSchema object" do
-      class InputSchemaTool < Tool
-        input_schema InputSchema.new(properties: { message: { type: "string" } }, required: [:message])
+      class InputSchemaTool
+        extend Tool
+
+        input_schema Tool::InputSchema.new(properties: { message: { type: "string" } }, required: [:message])
       end
 
       tool = InputSchemaTool
@@ -178,7 +185,9 @@ module MCP
     end
 
     test "Tool class method annotations can be set and retrieved" do
-      class AnnotationsTestTool < Tool
+      class AnnotationsTestTool
+        extend Tool
+
         tool_name "annotations_test"
         annotations(
           title: "Annotations Test",
@@ -193,7 +202,9 @@ module MCP
     end
 
     test "Tool class method annotations can be updated" do
-      class UpdatableAnnotationsTool < Tool
+      class UpdatableAnnotationsTool
+        extend Tool
+
         tool_name "updatable_annotations"
       end
 
@@ -206,7 +217,9 @@ module MCP
     end
 
     test "#call with Sorbet typed tools invokes the tool block and returns the response" do
-      class TypedTestTool < Tool
+      class TypedTestTool
+        extend Tool
+
         tool_name "test_tool"
         description "a test tool for testing"
         input_schema({ properties: { message: { type: "string" } }, required: ["message"] })


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

Classes are meant to be instantiated, but we expect consumers to use "macros" and define a singleton `call` method, so we should have them `extend` a `Module` instead.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

The tests have been updated.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

Consumers will need to update their tools and prompts to use the module based approach instead of the class based approach. **We could facilitate this by providing an autocorrecting RuboCop cop.**

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
