### PR TITLE
Suppress `Interrupt` exception for stdio server

### DIFF
--- a/lib/mcp/server/transports/stdio_transport.rb
+++ b/lib/mcp/server/transports/stdio_transport.rb
@@ -7,6 +7,8 @@ module MCP
   class Server
     module Transports
       class StdioTransport < Transport
+        STATUS_INTERRUPTED = Signal.list["INT"] + 128
+
         def initialize(server)
           @server = server
           @open = false
@@ -20,6 +22,10 @@ module MCP
           while @open && (line = $stdin.gets)
             handle_json_request(line.strip)
           end
+        rescue Interrupt
+          warn("\nExiting...")
+
+          exit(STATUS_INTERRUPTED)
         end
 
         def close


### PR DESCRIPTION
## Motivation and Context

This PR suppresses the following backtrace of `Interrupt` (Ctrl+c) exception for stdio server:

### Before

```console
$ ./examples/stdio_server.rb
^C/Users/koic/src/github.com/modelcontextprotocol/ruby-sdk/lib/mcp/server/transports/stdio_transport.rb:20:
in 'IO#gets': Interrupt
        from /Users/koic/src/github.com/modelcontextprotocol/ruby-sdk/lib/mcp/server/transports/stdio_transport.rb:20:
             in 'MCP::Server::Transports::StdioTransport#open'
        from ./examples/stdio_server.rb:95:in '<main>'
$ echo $?
130
```

### After

```console
$ ./examples/stdio_server.rb
^C
Exiting...
$ echo $?
130
```

This change should prevent unexpected backtrace from appearing when running the example: https://github.com/modelcontextprotocol/ruby-sdk?tab=readme-ov-file#stdio-transport

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
