### PR TITLE
[Doc] Add links to badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# MCP Ruby SDK ![Gem Version](https://img.shields.io/gem/v/mcp) ![MIT licensed](https://img.shields.io/badge/license-MIT-green) [![CI](https://github.com/modelcontextprotocol/ruby-sdk/actions/workflows/ci.yml/badge.svg)](https://github.com/modelcontextprotocol/ruby-sdk/actions/workflows/ci.yml)
+# MCP Ruby SDK [![Gem Version](https://img.shields.io/gem/v/mcp)](https://rubygems.org/gems/mcp) [![MIT licensed](https://img.shields.io/badge/license-MIT-green)](https://github.com/modelcontextprotocol/ruby-sdk/blob/main/LICENSE.txt) [![CI](https://github.com/modelcontextprotocol/ruby-sdk/actions/workflows/ci.yml/badge.svg)](https://github.com/modelcontextprotocol/ruby-sdk/actions/workflows/ci.yml)
 
 The official Ruby SDK for Model Context Protocol servers and clients.
 


### PR DESCRIPTION
## Motivation and Context

This PR adds links to the following two badges:

1. RubyGems badge: A link to the `mcp` gem will be added. The repository name is `ruby-sdk`, following the modelcontextprotocol org's naming convention. Since the repository name and the gem name are different, the link will help make it clear which gem it refers to.
2. MIT license badge: This will link to the MIT license file in the repository.

NOTE: Separately from this PR, the copyright notice in the MIT license should probably be addressed. It currently says `Copyright (c) 2025 TODO: Write your name`, so the TODO should be resolved: https://github.com/modelcontextprotocol/ruby-sdk/blob/v0.1.0/LICENSE.txt#L3

Other language SDKs seem to list `Anthropic, PBC` as the copyright holder, though I would defer that decision to someone more knowledgeable.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
