### PR TITLE
Remove duplicate `method` instrumentation

### DIFF
--- a/lib/mcp/server.rb
+++ b/lib/mcp/server.rb
@@ -176,7 +176,6 @@ module MCP
     end
 
     def init(request)
-      add_instrumentation_data(method: Methods::INITIALIZE)
       {
         protocolVersion: configuration.protocol_version,
         capabilities: capabilities,
@@ -185,12 +184,10 @@ module MCP
     end
 
     def list_tools(request)
-      add_instrumentation_data(method: Methods::TOOLS_LIST)
       @tools.map { |_, tool| tool.to_h }
     end
 
     def call_tool(request)
-      add_instrumentation_data(method: Methods::TOOLS_CALL)
       tool_name = request[:name]
       tool = tools[tool_name]
       unless tool
@@ -224,12 +221,10 @@ module MCP
     end
 
     def list_prompts(request)
-      add_instrumentation_data(method: Methods::PROMPTS_LIST)
       @prompts.map { |_, prompt| prompt.to_h }
     end
 
     def get_prompt(request)
-      add_instrumentation_data(method: Methods::PROMPTS_GET)
       prompt_name = request[:name]
       prompt = @prompts[prompt_name]
       unless prompt
@@ -246,21 +241,16 @@ module MCP
     end
 
     def list_resources(request)
-      add_instrumentation_data(method: Methods::RESOURCES_LIST)
-
       @resources.map(&:to_h)
     end
 
     # Server implementation should set `resources_read_handler` to override no-op default
     def read_resource_no_content(request)
-      add_instrumentation_data(method: Methods::RESOURCES_READ)
       add_instrumentation_data(resource_uri: request[:uri])
       []
     end
 
     def list_resource_templates(request)
-      add_instrumentation_data(method: Methods::RESOURCES_TEMPLATES_LIST)
-
       @resource_templates.map(&:to_h)
     end
 


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

This removes duplicate calls to `add_instrumentation_data(method: ...)`.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

`handle_request` already adds the `method` to the instrumentation data, so there is no need to repeat this. Moreover, consumers can override these anyway.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

This is covered by existing tests.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
There is no visible change, just a reduction in duplicate work.

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- ~I have added appropriate error handling~ _N/A_
- ~I have added or updated documentation as needed~ _N/A_

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->

I left behind some calls to `add_instrumentation_data` which could have been moved.

```ruby
def read_resource_no_content(request)
  add_instrumentation_data(resource_uri: request[:uri])
  []
end
```

I wasn't sure if we wanted _all_ reads to unconditionally instrument the URI.


```ruby
def call_tool(request)
  tool_name = request[:name]
  tool = tools[tool_name]
  unless tool
    add_instrumentation_data(error: :tool_not_found)
    raise RequestHandlerError.new("Tool not found #{tool_name}", request, error_type: :tool_not_found)
  end

  arguments = request[:arguments]
  add_instrumentation_data(tool_name:)

  # ...
end
```

I wasn't sure if we wanted to unconditionally instrument the `tool_name`, or only instrument _known_ tools (as we do now).

```ruby
def get_prompt(request)
  prompt_name = request[:name]
  prompt = @prompts[prompt_name]
  unless prompt
    add_instrumentation_data(error: :prompt_not_found)
    raise RequestHandlerError.new("Prompt not found #{prompt_name}", request, error_type: :prompt_not_found)
  end

  add_instrumentation_data(prompt_name:)

  # ...
end
```

Likewise, I wasn't sure if we only want to instrument _known_ prompts.
