### PR TITLE
Remove shebang from example files

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The server supports sending notifications to clients when lists of tools, prompt
 
 The server provides three notification methods:
 - `notify_tools_list_changed()` - Send a notification when the tools list changes
-- `notify_prompts_list_changed()` - Send a notification when the prompts list changes  
+- `notify_prompts_list_changed()` - Send a notification when the prompts list changes
 - `notify_resources_list_changed()` - Send a notification when the resources list changes
 
 #### Notification Format
@@ -119,7 +119,6 @@ end
 If you want to build a local command-line application, you can use the stdio transport:
 
 ```ruby
-#!/usr/bin/env ruby
 require "mcp"
 require "mcp/server/transports/stdio_transport"
 
@@ -157,7 +156,7 @@ transport.open
 You can run this script and then type in requests to the server at the command line.
 
 ```bash
-$ ./examples/stdio_server.rb
+$ ruby examples/stdio_server.rb
 {"jsonrpc":"2.0","id":"1","method":"ping"}
 {"jsonrpc":"2.0","id":"2","method":"tools/list"}
 ```

--- a/examples/README.md
+++ b/examples/README.md
@@ -9,7 +9,7 @@ A simple server that communicates over standard input/output. This is useful for
 
 **Usage:**
 ```bash
-ruby examples/stdio_server.rb
+$ ruby examples/stdio_server.rb
 {"jsonrpc":"2.0","id":0,"method":"tools/list"}
 ```
 
@@ -25,11 +25,11 @@ A standalone HTTP server built with Rack that implements the MCP Streamable HTTP
 
 **Usage:**
 ```bash
-ruby examples/http_server.rb
+$ ruby examples/http_server.rb
 ```
 
 The server will start on `http://localhost:9292` and provide:
-- **Tools**: 
+- **Tools**:
   - `ExampleTool` - adds two numbers
   - `echo` - echoes back messages
 - **Prompts**: `ExamplePrompt` - echoes back arguments as a prompt
@@ -41,12 +41,12 @@ A client that demonstrates how to interact with the HTTP server using all MCP pr
 **Usage:**
 1. Start the HTTP server in one terminal:
    ```bash
-   ruby examples/http_server.rb
+   $ ruby examples/http_server.rb
    ```
 
 2. Run the client example in another terminal:
    ```bash
-   ruby examples/http_client.rb
+   $ ruby examples/http_client.rb
    ```
 
 The client will demonstrate:
@@ -71,7 +71,7 @@ A specialized HTTP server designed to test and demonstrate Server-Sent Events (S
 
 **Usage:**
 ```bash
-ruby examples/streamable_http_server.rb
+$ ruby examples/streamable_http_server.rb
 ```
 
 The server will start on `http://localhost:9393` and provide detailed instructions for testing SSE functionality.
@@ -88,12 +88,12 @@ An interactive client that connects to the SSE stream and provides a menu-driven
 **Usage:**
 1. Start the SSE test server in one terminal:
    ```bash
-   ruby examples/streamable_http_server.rb
+   $ ruby examples/streamable_http_server.rb
    ```
 
 2. Run the SSE test client in another terminal:
    ```bash
-   ruby examples/streamable_http_client.rb
+   $ ruby examples/streamable_http_client.rb
    ```
 
 The client will:
@@ -133,7 +133,7 @@ curl -X POST http://localhost:9393 \
 
 The HTTP server implements the MCP Streamable HTTP transport protocol:
 
-1. **Initialize Session**: 
+1. **Initialize Session**:
    - Client sends POST request with `initialize` method
    - Server responds with session ID in `Mcp-Session-Id` header
 

--- a/examples/http_client.rb
+++ b/examples/http_client.rb
@@ -1,4 +1,3 @@
-#!/usr/bin/env ruby
 # frozen_string_literal: true
 
 require "net/http"

--- a/examples/http_server.rb
+++ b/examples/http_server.rb
@@ -1,4 +1,3 @@
-#!/usr/bin/env ruby
 # frozen_string_literal: true
 
 $LOAD_PATH.unshift(File.expand_path("../lib", __dir__))

--- a/examples/stdio_server.rb
+++ b/examples/stdio_server.rb
@@ -1,4 +1,3 @@
-#!/usr/bin/env ruby
 # frozen_string_literal: true
 
 $LOAD_PATH.unshift(File.expand_path("../lib", __dir__))

--- a/examples/streamable_http_client.rb
+++ b/examples/streamable_http_client.rb
@@ -1,4 +1,3 @@
-#!/usr/bin/env ruby
 # frozen_string_literal: true
 
 require "net/http"

--- a/examples/streamable_http_server.rb
+++ b/examples/streamable_http_server.rb
@@ -1,4 +1,3 @@
-#!/usr/bin/env ruby
 # frozen_string_literal: true
 
 $LOAD_PATH.unshift(File.expand_path("../lib", __dir__))


### PR DESCRIPTION
## Motivation and Context

Since the example files are not executable binaries, this PR removes the shebangs.

This ensures that all examples are consistently executed via `ruby` command. It also removes the executable permission from `examples/stdio_server.rb` using `chmod 444`, bringing it in line with the other example files.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
