### PR TITLE
Remove `json-schema` limit and reorganize dev deps

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,3 +4,6 @@ inherit_gem:
 plugins:
   - rubocop-minitest
   - rubocop-rake
+
+Gemspec/DevelopmentDependencies:
+  Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -7,11 +7,18 @@ gemspec
 
 # Specify development dependencies below
 gem "minitest", "~> 5.1", require: false
-gem "rake", "~> 13.0"
-gem "rubocop-minitest"
-gem "rubocop-rake"
-gem "rubocop-shopify", require: false
-
 gem "minitest-reporters"
 gem "mocha"
+
+gem "rubocop-minitest", require: false
+gem "rubocop-rake", require: false
+gem "rubocop-shopify", require: false
+
+gem "puma", ">= 5.0.0"
+gem "rack", ">= 2.0.0"
+gem "rackup", ">= 2.1.0"
+
+gem "activesupport"
 gem "debug"
+gem "rake", "~> 13.0"
+gem "sorbet-static-and-runtime"

--- a/mcp.gemspec
+++ b/mcp.gemspec
@@ -29,9 +29,4 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency("json_rpc_handler", "~> 0.1")
   spec.add_dependency("json-schema", "~> 4.1")
-  spec.add_development_dependency("activesupport")
-  spec.add_development_dependency("puma", ">= 5.0.0")
-  spec.add_development_dependency("rack", ">= 2.0.0")
-  spec.add_development_dependency("rackup", ">= 2.1.0")
-  spec.add_development_dependency("sorbet-static-and-runtime")
 end

--- a/mcp.gemspec
+++ b/mcp.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency("json_rpc_handler", "~> 0.1")
-  spec.add_dependency("json-schema", "~> 4.1")
+  spec.add_dependency("json-schema", ">= 4.1")
 end


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

We're currently limiting the `json-schema` gem to `~> 4.1`, which means applications using a `5.x` version get a dependency conflict. This addresses that.

While I was at it, I also moved all development dependencies to `Gemfile` for consistency.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

No, but the only breaking change in `json-schema@5.0`'s changelog is dropping support for Ruby versions older than the minimum one we support.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

None

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- ~I have added appropriate error handling~
- ~I have added or updated documentation as needed~

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
