### PR TITLE
Disable release workflow on forks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
       - 'lib/mcp/version.rb'
 jobs:
   publish_gem:
+    if: github.repository_owner == 'modelcontextprotocol'
     name: Release Gem Version to RubyGems.org
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
:wave: I'm seeing the release workflow being triggered in my fork:

https://github.com/andyw8/ruby-sdk/actions/runs/15765079609