### PR TITLE
fixes input schema validation for schemas without required fields

### DIFF
--- a/lib/mcp/tool/input_schema.rb
+++ b/lib/mcp/tool/input_schema.rb
@@ -16,7 +16,9 @@ module MCP
       end
 
       def to_h
-        { type: "object", properties:, required: }
+        { type: "object", properties: }.tap do |hsh|
+          hsh[:required] = required if required.any?
+        end
       end
 
       def missing_required_arguments?(arguments)

--- a/test/mcp/tool/input_schema_test.rb
+++ b/test/mcp/tool/input_schema_test.rb
@@ -40,6 +40,12 @@ module MCP
         end
       end
 
+      test "schema without required arguments is valid" do
+        assert_nothing_raised do
+          InputSchema.new(properties: { foo: { type: "string" } })
+        end
+      end
+
       test "validate arguments with valid data" do
         schema = InputSchema.new(properties: { foo: { type: "string" } }, required: [:foo])
         assert_nil(schema.validate_arguments({ foo: "bar" }))


### PR DESCRIPTION
Input Schemas that declare no required properties raised an ArgumentError due to the present but empty `required` field in `InputSchema#to_h`.

A test case reproducing the issue is included in the patch.
