### PR TITLE
run `workflows/release.yml` in release environment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,17 @@
 name: Release new version
 on:
   push:
-    branches: [ main ]
+    branches: [main]
     paths:
-      - 'lib/mcp/version.rb'
+      - "lib/mcp/version.rb"
 jobs:
   publish_gem:
     if: github.repository_owner == 'modelcontextprotocol'
     name: Release Gem Version to RubyGems.org
     runs-on: ubuntu-latest
+
+    environment: release
+
     permissions:
       id-token: write # IMPORTANT: this permission is mandatory for trusted publishing
       contents: write # IMPORTANT: this permission is required for `rake release` to push the release tag


### PR DESCRIPTION
## Motivation and Context

trusted publishing is set up on the `release` environment, so the workflow needs to run there.

## How Has This Been Tested?

📖 
https://guides.rubygems.org/trusted-publishing/releasing-gems/ 

👁️ 
https://github.com/modelcontextprotocol/ruby-sdk/blob/520205cad2d0c61faa6889fdc027c8b15086b1f8/.github/workflows/release.yml#L12-L14

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

