### PR TITLE
Validate `protocol_version` value

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,8 @@ This will make all new server instances use the specified protocol version inste
 MCP::Server.protocol_version = nil
 ```
 
+If an invalid `protocol_version` value is set, an `ArgumentError` is raised.
+
 Be sure to check the [MCP spec](https://modelcontextprotocol.io/specification/2025-03-26) for the protocol version to understand the supported features for the version being set.
 
 ### Exception Reporting

--- a/lib/mcp/configuration.rb
+++ b/lib/mcp/configuration.rb
@@ -3,6 +3,7 @@
 module MCP
   class Configuration
     DEFAULT_PROTOCOL_VERSION = "2024-11-05"
+    SUPPORTED_PROTOCOL_VERSIONS = ["2025-06-18", "2025-03-26", DEFAULT_PROTOCOL_VERSION]
 
     attr_writer :exception_reporter, :instrumentation_callback, :protocol_version, :validate_tool_call_arguments
 
@@ -11,6 +12,10 @@ module MCP
       @exception_reporter = exception_reporter
       @instrumentation_callback = instrumentation_callback
       @protocol_version = protocol_version
+      if protocol_version && !SUPPORTED_PROTOCOL_VERSIONS.include?(protocol_version)
+        message = "protocol_version must be #{SUPPORTED_PROTOCOL_VERSIONS[0...-1].join(", ")}, or #{SUPPORTED_PROTOCOL_VERSIONS[-1]}"
+        raise ArgumentError, message
+      end
       unless validate_tool_call_arguments.is_a?(TrueClass) || validate_tool_call_arguments.is_a?(FalseClass)
         raise ArgumentError, "validate_tool_call_arguments must be a boolean"
       end

--- a/test/mcp/configuration_test.rb
+++ b/test/mcp/configuration_test.rb
@@ -48,18 +48,18 @@ module MCP
     end
 
     test "merges protocol version from other configuration" do
-      config1 = Configuration.new(protocol_version: "2025-03-27")
-      config2 = Configuration.new(protocol_version: "2025-03-28")
+      config1 = Configuration.new(protocol_version: "2025-03-26")
+      config2 = Configuration.new(protocol_version: "2025-06-18")
       config3 = Configuration.new
 
       merged = config1.merge(config2)
-      assert_equal "2025-03-28", merged.protocol_version
+      assert_equal "2025-06-18", merged.protocol_version
 
       merged = config1.merge(config3)
-      assert_equal "2025-03-27", merged.protocol_version
+      assert_equal "2025-03-26", merged.protocol_version
 
       merged = config3.merge(config1)
-      assert_equal "2025-03-27", merged.protocol_version
+      assert_equal "2025-03-26", merged.protocol_version
     end
 
     test "defaults validate_tool_call_arguments to true" do
@@ -96,10 +96,18 @@ module MCP
       refute merged.validate_tool_call_arguments
     end
 
+    test "raises ArgumentError when protocol_version is not a supported value" do
+      exception = assert_raises(ArgumentError) do
+        Configuration.new(protocol_version: "1999-12-31")
+      end
+      assert_match(/\Aprotocol_version must be/, exception.message)
+    end
+
     test "raises ArgumentError when validate_tool_call_arguments is not a boolean" do
-      assert_raises(ArgumentError) do
+      exception = assert_raises(ArgumentError) do
         Configuration.new(validate_tool_call_arguments: "true")
       end
+      assert_equal("validate_tool_call_arguments must be a boolean", exception.message)
     end
   end
 end

--- a/test/mcp/server_test.rb
+++ b/test/mcp/server_test.rb
@@ -804,7 +804,7 @@ module MCP
     end
 
     test "server protocol version can be overridden via configuration" do
-      custom_version = "2025-03-27"
+      custom_version = "2025-03-26"
       configuration = Configuration.new(protocol_version: custom_version)
       server = Server.new(name: "test_server", configuration: configuration)
 


### PR DESCRIPTION
## Motivation and Context

Currently, MCP supports the following three protocol versions: "2025-06-18", "2025-03-26", and "2024-11-05".
https://modelcontextprotocol.io/introduction

As shown in the changes to `test/mcp/configuration_test.rb`, the `protocol_version` value is not currently being validated, which allows unexpected `protocol_version` values to be accepted.

This PR ensures that only supported protocol versions are accepted.

## How Has This Been Tested?

Existing tests have been updated and new tests have been added.

## Breaking Changes

None. If it becomes an issue, it means a value that was not originally intended has been used.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

While one possible approach might be to fall back to a default protocol version when an invalid `protocol_version` value is provided, this PR opts to reject invalid `protocol_version` values explicitly. The reasoning is that encouraging users to provide intentional, valid input is preferable to silently falling back to a default, which could lead to unexpected behavior.
