### PR TITLE
Set default protocol version to the latest specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ server.notify_tools_list_changed()
 #### Rails Controller
 
 When added to a Rails controller on a route that handles POST requests, your server will be compliant with non-streaming
-[Streamable HTTP](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http) transport
+[Streamable HTTP](https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#streamable-http) transport
 requests.
 
 You can use the `Server#handle_json` method to handle requests.
@@ -340,7 +340,7 @@ MCP::Server.protocol_version = nil
 
 If an invalid `protocol_version` value is set, an `ArgumentError` is raised.
 
-Be sure to check the [MCP spec](https://modelcontextprotocol.io/specification/2025-03-26) for the protocol version to understand the supported features for the version being set.
+Be sure to check the [MCP spec](https://modelcontextprotocol.io/specification) for the protocol version to understand the supported features for the version being set.
 
 ### Exception Reporting
 

--- a/lib/mcp/configuration.rb
+++ b/lib/mcp/configuration.rb
@@ -2,8 +2,8 @@
 
 module MCP
   class Configuration
-    DEFAULT_PROTOCOL_VERSION = "2024-11-05"
-    SUPPORTED_PROTOCOL_VERSIONS = ["2025-06-18", "2025-03-26", DEFAULT_PROTOCOL_VERSION]
+    DEFAULT_PROTOCOL_VERSION = "2025-06-18"
+    SUPPORTED_PROTOCOL_VERSIONS = [DEFAULT_PROTOCOL_VERSION, "2025-03-26", "2024-11-05"]
 
     attr_writer :exception_reporter, :instrumentation_callback, :protocol_version, :validate_tool_call_arguments
 

--- a/test/mcp/server/transports/streamable_http_transport_test.rb
+++ b/test/mcp/server/transports/streamable_http_transport_test.rb
@@ -84,7 +84,7 @@ module MCP
           body = JSON.parse(response[2][0])
           assert_equal "2.0", body["jsonrpc"]
           assert_equal "123", body["id"]
-          assert_equal "2024-11-05", body["result"]["protocolVersion"]
+          assert_equal "2025-06-18", body["result"]["protocolVersion"]
         end
 
         test "handles GET request with valid session ID" do

--- a/test/mcp/server_test.rb
+++ b/test/mcp/server_test.rb
@@ -114,7 +114,7 @@ module MCP
         jsonrpc: "2.0",
         id: 1,
         result: {
-          protocolVersion: "2024-11-05",
+          protocolVersion: "2025-06-18",
           capabilities: {
             prompts: { listChanged: true },
             resources: { listChanged: true },


### PR DESCRIPTION
## Motivation and Context

Currently, MCP has three versions: 2024-11-05, 2025-03-26, and 2025-06-18.

- https://modelcontextprotocol.io/specification/2024-11-05/basic/transports (stdio and HTTP with SSE)
- https://modelcontextprotocol.io/specification/2025-03-26/basic/transports (stdio and Streamable HTTP)
- https://modelcontextprotocol.io/specification/2025-06-18/basic/transports (stdio and Streamable HTTP)

The newer specification supports stdio and Streamable HTTP as transport mechanisms. Only the oldest version, 2024-11-05, supports stdin and HTTP with SSE, but that version is now considered legacy.

Given the current behavior of the Ruby SDK, it likely makes more sense to set the default protocol version to the latest one, 2025-06-18, rather than the oldest, 2024-11-05.

## How Has This Been Tested?

Existing tests have been updated.

## Breaking Changes

None.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

Ideally, the implementation should adjust its behavior based on the version, but this PR is limited to updating the default protocol version only.
