### PR TITLE
implements the notifications/initialized method

### DIFF
--- a/lib/mcp/server.rb
+++ b/lib/mcp/server.rb
@@ -74,6 +74,7 @@ module MCP
         Methods::PROMPTS_GET => method(:get_prompt),
         Methods::INITIALIZE => method(:init),
         Methods::PING => ->(_) { {} },
+        Methods::NOTIFICATIONS_INITIALIZED => ->(_) {},
 
         # No op handlers for currently unsupported methods
         Methods::RESOURCES_SUBSCRIBE => ->(_) {},

--- a/test/mcp/server_test.rb
+++ b/test/mcp/server_test.rb
@@ -160,6 +160,26 @@ module MCP
       assert_instrumentation_data({ method: "unsupported_method" })
     end
 
+    test "#handle notifications/initialized returns nil response" do
+      request = {
+        jsonrpc: "2.0",
+        method: "notifications/initialized",
+      }
+
+      assert_nil @server.handle(request)
+      assert_instrumentation_data({ method: "notifications/initialized" })
+    end
+
+    test "#handle_json notifications/initialized returns nil response" do
+      request = JSON.generate({
+        jsonrpc: "2.0",
+        method: "notifications/initialized",
+      })
+
+      assert_nil @server.handle_json(request)
+      assert_instrumentation_data({ method: "notifications/initialized" })
+    end
+
     test "#handle tools/list returns available tools" do
       request = {
         jsonrpc: "2.0",


### PR DESCRIPTION
According to https://modelcontextprotocol.io/specification/2025-06-18/basic/lifecycle, "After successful initialization, the client MUST send an initialized notification to indicate it is ready to begin normal operations".

This implementation just replies with an empty response (same as ping).

## Motivation and Context

Claude Code assumed the MCP server wasn't working when this method was not handled gracefully.

## How Has This Been Tested?

test case added, works in my app.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

