### PR TITLE
Fix tools with no args

### DIFF
--- a/lib/mcp/server.rb
+++ b/lib/mcp/server.rb
@@ -314,7 +314,7 @@ module MCP
     end
 
     def call_tool_with_args(tool, arguments)
-      args = arguments.transform_keys(&:to_sym)
+      args = arguments&.transform_keys(&:to_sym) || {}
 
       if accepts_server_context?(tool.method(:call))
         tool.call(**args, server_context: server_context).to_h


### PR DESCRIPTION
## Motivation and Context

This PR fixes a bug in the ruby-sdk where if a tool provided has zero arguments it will throw an error. In order to resolve this the following line needed updating to handle `nil` case:
`args = arguments&.transform_keys(&:to_sym) || {}`

Example of tools not requiring args e.g. Listing a set of resources available / configuration.

## How Has This Been Tested?

Tested in local application and added unit test for this case

## Breaking Changes

No breaking change

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
