### PR TITLE
Add `instructions` support to `MCP::Server`

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,11 +155,11 @@ You can use the `Server#handle_json` method to handle requests.
 
 ```ruby
 class ApplicationController < ActionController::Base
-
   def index
     server = MCP::Server.new(
       name: "my_server",
       version: "1.0.0",
+      instructions: "Use the tools of this server as a last resort",
       tools: [SomeTool, AnotherTool],
       prompts: [MyPrompt],
       server_context: { user_id: current_user.id },


### PR DESCRIPTION
## Motivation and Context

The response of the `init` method can include `instructions`. https://modelcontextprotocol.io/specification/2025-06-18/basic/lifecycle

`instructions` appear to be supported starting from the 2025-03-26 specification.

- https://modelcontextprotocol.io/specification/2025-03-26/basic/lifecycle (supports `instructions`)
- https://modelcontextprotocol.io/specification/2024-11-05/basic/lifecycle (does not support `instructions`)

If `instructions` is used with an unsupported protocol version, an `ArgumentError` will be raised.

## How Has This Been Tested?

Existing tests have been updated and new tests have been added.

## Breaking Changes

None.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

As additional context, the TypeScript SDK also treats `instructions` as optional. https://github.com/modelcontextprotocol/typescript-sdk/blob/1.16.0/src/types.ts#L356-L361
