### PR TITLE
[Doc] Fix incorrect example for configuring protocol version

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,16 +326,17 @@ config.instrumentation_callback = ->(data) {
 
 ### Server Protocol Version
 
-The server's protocol version can be overridden using the `protocol_version` class method:
+The server's protocol version can be overridden using the `protocol_version` keyword argument:
 
 ```ruby
-MCP::Server.protocol_version = "2024-11-05"
+configuration = MCP::Configuration.new(protocol_version: "2024-11-05")
+MCP::Server.new(name: "test_server", configuration: configuration)
 ```
 
 This will make all new server instances use the specified protocol version instead of the default version. The protocol version can be reset to the default by setting it to `nil`:
 
 ```ruby
-MCP::Server.protocol_version = nil
+MCP::Configuration.new(protocol_version: nil)
 ```
 
 If an invalid `protocol_version` value is set, an `ArgumentError` is raised.


### PR DESCRIPTION
## Motivation and Context

`MCP::Server` does not have a `protocol_version=` method.

```console
$ bin/console
irb(main):001> MCP::Server.protocol_version = "2024-11-05"
(irb):1:in '<main>': undefined method 'protocol_version=' for class MCP::Server (NoMethodError)
        from bin/console:15:in '<main>'
```

This PR fixes an incorrect example that causes the above error.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed
