### PR TITLE
Clarify resource read handler in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -575,7 +575,7 @@ server.resources_read_handler do |params|
   [{
     uri: params[:uri],
     mimeType: "text/plain",
-    text: params[:uri],
+    text: "Hello from example resource! URI: #{params[:uri]}"
   }]
 end
 


### PR DESCRIPTION
This better matches the code in `/examples` and helps illustrate the usage.