### PR TITLE
[test] minites-reporters do not work with RubyMine

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,6 @@ gemspec
 
 # Specify development dependencies below
 gem "minitest", "~> 5.1", require: false
-gem "minitest-reporters"
 gem "mocha"
 
 gem "rubocop-minitest", require: false

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,7 +3,6 @@
 require "mcp"
 
 require "minitest/autorun"
-require "minitest/reporters"
 require "minitest/mock"
 require "mocha/minitest"
 
@@ -13,5 +12,3 @@ require "active_support/test_case"
 require "sorbet-runtime"
 
 require_relative "instrumentation_test_helper"
-
-Minitest::Reporters.use!(Minitest::Reporters::ProgressReporter.new)


### PR DESCRIPTION
Disable Minitest::Reporters when running tests in RubyMine

## Motivation and Context
I want to execute tests directly in ruby mine and Minitest::Reporters is not compatible with RubyMine test runner

## How Has This Been Tested?
Locally running tests in and outside of RubyMine

## Breaking Changes
none

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [X] Dev tools support

## Checklist
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [X] I have added appropriate error handling
- [X] I have added or updated documentation as needed
