### PR TITLE
Empty inputSchema requires the type key

### DIFF
--- a/lib/mcp/tool.rb
+++ b/lib/mcp/tool.rb
@@ -6,7 +6,6 @@ module MCP
       NOT_SET = Object.new
 
       attr_reader :description_value
-      attr_reader :input_schema_value
       attr_reader :annotations_value
 
       def call(*args, server_context: nil)
@@ -41,6 +40,10 @@ module MCP
 
       def name_value
         @name_value || StringUtils.handle_from_class_name(name)
+      end
+
+      def input_schema_value
+        @input_schema_value || InputSchema.new
       end
 
       def description(value = NOT_SET)

--- a/lib/mcp/tool/input_schema.rb
+++ b/lib/mcp/tool/input_schema.rb
@@ -15,8 +15,13 @@ module MCP
         validate_schema!
       end
 
+      def ==(other)
+        other.is_a?(InputSchema) && properties == other.properties && required == other.required
+      end
+
       def to_h
-        { type: "object", properties: }.tap do |hsh|
+        { type: "object" }.tap do |hsh|
+          hsh[:properties] = properties if properties.any?
           hsh[:required] = required if required.any?
         end
       end

--- a/test/mcp/server_test.rb
+++ b/test/mcp/server_test.rb
@@ -164,7 +164,7 @@ module MCP
       assert_kind_of Array, result[:tools]
       assert_equal "test_tool", result[:tools][0][:name]
       assert_equal "Test tool", result[:tools][0][:description]
-      assert_empty(result[:tools][0][:inputSchema])
+      assert_equal({ type: "object" }, result[:tools][0][:inputSchema])
       assert_instrumentation_data({ method: "tools/list" })
     end
 

--- a/test/mcp/tool/input_schema_test.rb
+++ b/test/mcp/tool/input_schema_test.rb
@@ -79,6 +79,21 @@ module MCP
           InputSchema.new(properties: { foo: { :$ref => "#/definitions/bar" } }, required: [:foo])
         end
       end
+
+      test "== compares two input schemas with the same properties and required fields" do
+        schema1 = InputSchema.new(properties: { foo: { type: "string" } }, required: [:foo])
+        schema2 = InputSchema.new(properties: { foo: { type: "string" } }, required: [:foo])
+        assert_equal schema1, schema2
+
+        schema3 = InputSchema.new(properties: { bar: { type: "string" } }, required: [:bar])
+        refute_equal schema1, schema3
+
+        schema4 = InputSchema.new(properties: { foo: { type: "string" } }, required: [:bar])
+        refute_equal schema1, schema4
+
+        schema5 = InputSchema.new(properties: { bar: { type: "string" } }, required: [:foo])
+        refute_equal schema1, schema5
+      end
     end
   end
 end

--- a/test/mcp/tool_test.rb
+++ b/test/mcp/tool_test.rb
@@ -26,7 +26,7 @@ module MCP
 
     test "#to_h returns a hash with name, description, and inputSchema" do
       tool = Tool.define(name: "mock_tool", description: "a mock tool for testing")
-      assert_equal tool.to_h, { name: "mock_tool", description: "a mock tool for testing", inputSchema: {} }
+      assert_equal tool.to_h, { name: "mock_tool", description: "a mock tool for testing", inputSchema: { type: "object" } }
     end
 
     test "#to_h includes annotations when present" do
@@ -71,6 +71,15 @@ module MCP
       assert_equal tool.tool_name, "default_name_tool"
     end
 
+    test "input schema defaults to an empty hash" do
+      class NoInputSchemaTool < Tool; end
+
+      tool = NoInputSchemaTool
+
+      expected = { type: "object" }
+      assert_equal expected, tool.input_schema.to_h
+    end
+
     test "accepts input schema as an InputSchema object" do
       class InputSchemaTool < Tool
         input_schema InputSchema.new(properties: { message: { type: "string" } }, required: [:message])
@@ -106,7 +115,7 @@ module MCP
 
       assert_equal tool.name_value, "mock_tool"
       assert_equal tool.description, "a mock tool for testing"
-      assert_equal tool.input_schema, nil
+      assert_equal tool.input_schema, Tool::InputSchema.new
     end
 
     test ".define allows definition of tools with annotations" do
@@ -123,7 +132,7 @@ module MCP
 
       assert_equal tool.name_value, "mock_tool"
       assert_equal tool.description, "a mock tool for testing"
-      assert_equal tool.input_schema, nil
+      assert_equal tool.input_schema, Tool::InputSchema.new
       assert_equal tool.annotations_value.to_h, { title: "Mock Tool", readOnlyHint: true }
     end
 


### PR DESCRIPTION
When defining a tool without any arguments taken, it should be allowed to not have to define the `input_schema` at all, and the default value for such a scenario should be `{ type: "object" }` as per the schema.

https://github.com/modelcontextprotocol/modelcontextprotocol/blob/16d91abb68bbc824944c5bda4ac2e2ccaaa74b0f/schema/2025-06-18/schema.ts#L896-L900

<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
When testing a tool without the `input_schema` defined, the `mcp-inspector` returns an error when trying to list the tool:

```
Error
[ { "code": "invalid_type", "expected": "object", "received": "undefined", "path": [ "tools", 1, "inputSchema" ], "message": "Required" } ]
```

## How Has This Been Tested?
Added new tests and locally using the `mcp-inspector`.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
