### PR TITLE
Response error keyword argument

### DIFF
--- a/lib/mcp/tool/response.rb
+++ b/lib/mcp/tool/response.rb
@@ -3,15 +3,26 @@
 module MCP
   class Tool
     class Response
-      attr_reader :content, :is_error
+      NOT_GIVEN = Object.new.freeze
 
-      def initialize(content, is_error = false)
+      attr_reader :content
+
+      def initialize(content, deprecated_error = NOT_GIVEN, error: false)
+        if deprecated_error != NOT_GIVEN
+          warn("Passing `error` with the 2nd argument of `Response.new` is deprecated. Use keyword argument like `Response.new(content, error: error)` instead.", uplevel: 1)
+          error = deprecated_error
+        end
+
         @content = content
-        @is_error = is_error
+        @error = error
+      end
+
+      def error?
+        !!@error
       end
 
       def to_h
-        { content:, isError: is_error }.compact
+        { content:, isError: error? }.compact
       end
     end
   end

--- a/test/mcp/tool/response_test.rb
+++ b/test/mcp/tool/response_test.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module MCP
+  class Tool
+    class ResponseTest < ActiveSupport::TestCase
+      test "#initialize with content" do
+        content = [{
+          type: "text",
+          text: "Unauthorized",
+        }]
+        response = Response.new(content)
+
+        assert_equal content, response.content
+        refute response.error?
+      end
+
+      test "#initialize with content and error set to true" do
+        content = [{
+          type: "text",
+          text: "Unauthorized",
+        }]
+        response = Response.new(content, error: true)
+
+        assert_equal content, response.content
+        assert response.error?
+      end
+
+      test "#initialize with content and error explicitly set to false" do
+        content = [{
+          type: "text",
+          text: "Unauthorized",
+        }]
+        response = Response.new(content, error: false)
+
+        assert_equal content, response.content
+        refute response.error?
+      end
+
+      test "#error? for a standard response" do
+        response = Response.new(nil, error: false)
+        refute response.error?
+      end
+
+      test "#error? for an error response" do
+        response = Response.new(nil, error: true)
+        assert response.error?
+      end
+
+      test "#to_h for a standard response" do
+        content = [{
+          type: "text",
+          text: "Unauthorized",
+        }]
+        response = Response.new(content)
+        actual = response.to_h
+
+        assert_equal [:content, :isError].sort, actual.keys.sort
+        assert_equal content, actual[:content]
+        refute actual[:isError]
+      end
+
+      test "#to_h for an error response" do
+        content = [{
+          type: "text",
+          text: "Unauthorized",
+        }]
+        response = Response.new(content, error: true)
+        actual = response.to_h
+        assert_equal [:content, :isError].sort, actual.keys.sort
+        assert_equal content, actual[:content]
+        assert actual[:isError]
+      end
+    end
+  end
+end

--- a/test/mcp/tool_test.rb
+++ b/test/mcp/tool_test.rb
@@ -45,7 +45,7 @@ module MCP
       tool = TestTool
       response = tool.call(message: "test")
       assert_equal response.content, [{ type: "text", content: "OK" }]
-      assert_equal response.is_error, false
+      refute response.error?
     end
 
     test "allows declarative definition of tools as classes" do
@@ -250,7 +250,7 @@ module MCP
       tool = TypedTestTool
       response = tool.call(message: "test")
       assert_equal response.content, [{ type: "text", content: "OK" }]
-      assert_equal response.is_error, false
+      refute response.error?
     end
 
     class TestToolWithoutServerContext < Tool


### PR DESCRIPTION
The positional argument and naming is a bit awkward, and feels unnatural. Let's instead follow the Ruby style and add an `error:` keyword argument.

#### Before

```ruby
response = Response.new(content, true) # What is true?
```

#### After

```ruby
response = Response.new(content, error: true)
```


## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

## How Has This Been Tested?

Unit tests

## Breaking Changes

For anyone using the positional argument, this is a breaking change.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context

I'm happy to remove the second commit that introduces the `ErrorResponse` class. I do find it's usage a nicer approach that moves the decision to the caller, but also I can see how it adds some unnecessary boilerplate. Let me know what you think!