### PR TITLE
[Docs] Remove redundant parentheses

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,9 +108,9 @@ The server supports sending notifications to clients when lists of tools, prompt
 
 The server provides three notification methods:
 
-- `notify_tools_list_changed()` - Send a notification when the tools list changes
-- `notify_prompts_list_changed()` - Send a notification when the prompts list changes
-- `notify_resources_list_changed()` - Send a notification when the resources list changes
+- `notify_tools_list_changed` - Send a notification when the tools list changes
+- `notify_prompts_list_changed` - Send a notification when the prompts list changes
+- `notify_resources_list_changed` - Send a notification when the resources list changes
 
 #### Notification Format
 
@@ -134,7 +134,7 @@ server.transport = transport
 
 # When tools change, notify clients
 server.define_tool(name: "new_tool") { |**args| { result: "ok" } }
-server.notify_tools_list_changed()
+server.notify_tools_list_changed
 ```
 
 ### Unsupported Features ( to be implemented in future versions )


### PR DESCRIPTION
## Motivation and Context

In Ruby, it is generally not customary to add parentheses to methods without arguments. This PR removes such redundant parentheses from the documentation.

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
