### PR TITLE
Add title to tools, prompts and resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,7 @@ This gem provides a `MCP::Tool` class that can be used to create tools in two wa
 
 ```ruby
 class MyTool < MCP::Tool
+  title "My Tool"
   description "This tool performs specific functionality..."
   input_schema(
     properties: {
@@ -381,7 +382,6 @@ class MyTool < MCP::Tool
     required: ["message"]
   )
   annotations(
-    title: "My Tool",
     read_only_hint: true,
     destructive_hint: false,
     idempotent_hint: true,
@@ -401,9 +401,9 @@ tool = MyTool
 ```ruby
 tool = MCP::Tool.define(
   name: "my_tool",
+  title: "My Tool",
   description: "This tool performs specific functionality...",
   annotations: {
-    title: "My Tool",
     read_only_hint: true
   }
 ) do |args, server_context|
@@ -437,6 +437,7 @@ The `MCP::Prompt` class provides two ways to create prompts:
 ```ruby
 class MyPrompt < MCP::Prompt
   prompt_name "my_prompt"  # Optional - defaults to underscored class name
+  title "My Prompt"
   description "This prompt performs specific functionality..."
   arguments [
     MCP::Prompt::Argument.new(
@@ -473,6 +474,7 @@ prompt = MyPrompt
 ```ruby
 prompt = MCP::Prompt.define(
   name: "my_prompt",
+  title: "My Prompt",
   description: "This prompt performs specific functionality...",
   arguments: [
     MCP::Prompt::Argument.new(
@@ -558,7 +560,8 @@ The `MCP::Resource` class provides a way to register resources with the server.
 ```ruby
 resource = MCP::Resource.new(
   uri: "https://example.com/my_resource",
-  name: "My Resource",
+  name: "my-resource",
+  title: "My Resource",
   description: "Lorem ipsum dolor sit amet",
   mime_type: "text/html",
 )

--- a/examples/http_server.rb
+++ b/examples/http_server.rb
@@ -62,7 +62,8 @@ server = MCP::Server.new(
   resources: [
     MCP::Resource.new(
       uri: "https://test_resource.invalid",
-      name: "Test resource",
+      name: "test-resource",
+      title: "Test Resource",
       description: "Test resource that echoes back the uri as its content",
       mime_type: "text/plain",
     ),

--- a/examples/stdio_server.rb
+++ b/examples/stdio_server.rb
@@ -59,7 +59,8 @@ server = MCP::Server.new(
   resources: [
     MCP::Resource.new(
       uri: "https://test_resource.invalid",
-      name: "Test resource",
+      name: "test-resource",
+      title: "Test Resource",
       description: "Test resource that echoes back the uri as its content",
       mime_type: "text/plain",
     ),

--- a/lib/mcp/prompt.rb
+++ b/lib/mcp/prompt.rb
@@ -6,6 +6,7 @@ module MCP
     class << self
       NOT_SET = Object.new
 
+      attr_reader :title_value
       attr_reader :description_value
       attr_reader :arguments_value
 
@@ -14,12 +15,13 @@ module MCP
       end
 
       def to_h
-        { name: name_value, description: description_value, arguments: arguments_value.map(&:to_h) }.compact
+        { name: name_value, title: title_value, description: description_value, arguments: arguments_value.map(&:to_h) }.compact
       end
 
       def inherited(subclass)
         super
         subclass.instance_variable_set(:@name_value, nil)
+        subclass.instance_variable_set(:@title_value, nil)
         subclass.instance_variable_set(:@description_value, nil)
         subclass.instance_variable_set(:@arguments_value, nil)
       end
@@ -34,6 +36,14 @@ module MCP
 
       def name_value
         @name_value || StringUtils.handle_from_class_name(name)
+      end
+
+      def title(value = NOT_SET)
+        if value == NOT_SET
+          @title_value
+        else
+          @title_value = value
+        end
       end
 
       def description(value = NOT_SET)
@@ -52,9 +62,10 @@ module MCP
         end
       end
 
-      def define(name: nil, description: nil, arguments: [], &block)
+      def define(name: nil, title: nil, description: nil, arguments: [], &block)
         Class.new(self) do
           prompt_name name
+          title title
           description description
           arguments arguments
           define_singleton_method(:template) do |args, server_context: nil|

--- a/lib/mcp/resource.rb
+++ b/lib/mcp/resource.rb
@@ -3,21 +3,23 @@
 
 module MCP
   class Resource
-    attr_reader :uri, :name, :description, :mime_type
+    attr_reader :uri, :name, :title, :description, :mime_type
 
-    def initialize(uri:, name:, description: nil, mime_type: nil)
+    def initialize(uri:, name:, title: nil, description: nil, mime_type: nil)
       @uri = uri
       @name = name
+      @title = title
       @description = description
       @mime_type = mime_type
     end
 
     def to_h
       {
-        uri: @uri,
-        name: @name,
-        description: @description,
-        mimeType: @mime_type,
+        uri: uri,
+        name: name,
+        title: title,
+        description: description,
+        mimeType: mime_type,
       }.compact
     end
   end

--- a/lib/mcp/resource_template.rb
+++ b/lib/mcp/resource_template.rb
@@ -3,21 +3,23 @@
 
 module MCP
   class ResourceTemplate
-    attr_reader :uri_template, :name, :description, :mime_type
+    attr_reader :uri_template, :name, :title, :description, :mime_type
 
-    def initialize(uri_template:, name:, description: nil, mime_type: nil)
+    def initialize(uri_template:, name:, title: nil, description: nil, mime_type: nil)
       @uri_template = uri_template
       @name = name
+      @title = title
       @description = description
       @mime_type = mime_type
     end
 
     def to_h
       {
-        uriTemplate: @uri_template,
-        name: @name,
-        description: @description,
-        mimeType: @mime_type,
+        uriTemplate: uri_template,
+        name: name,
+        title: title,
+        description: description,
+        mimeType: mime_type,
       }.compact
     end
   end

--- a/lib/mcp/server.rb
+++ b/lib/mcp/server.rb
@@ -96,13 +96,13 @@ module MCP
       end
     end
 
-    def define_tool(name: nil, description: nil, input_schema: nil, annotations: nil, &block)
-      tool = Tool.define(name:, description:, input_schema:, annotations:, &block)
+    def define_tool(name: nil, title: nil, description: nil, input_schema: nil, annotations: nil, &block)
+      tool = Tool.define(name:, title:, description:, input_schema:, annotations:, &block)
       @tools[tool.name_value] = tool
     end
 
-    def define_prompt(name: nil, description: nil, arguments: [], &block)
-      prompt = Prompt.define(name:, description:, arguments:, &block)
+    def define_prompt(name: nil, title: nil, description: nil, arguments: [], &block)
+      prompt = Prompt.define(name:, title:, description:, arguments:, &block)
       @prompts[prompt.name_value] = prompt
     end
 

--- a/lib/mcp/tool.rb
+++ b/lib/mcp/tool.rb
@@ -5,6 +5,7 @@ module MCP
     class << self
       NOT_SET = Object.new
 
+      attr_reader :title_value
       attr_reader :description_value
       attr_reader :annotations_value
 
@@ -15,6 +16,7 @@ module MCP
       def to_h
         result = {
           name: name_value,
+          title: title_value,
           description: description_value,
           inputSchema: input_schema_value.to_h,
         }
@@ -25,6 +27,7 @@ module MCP
       def inherited(subclass)
         super
         subclass.instance_variable_set(:@name_value, nil)
+        subclass.instance_variable_set(:@title_value, nil)
         subclass.instance_variable_set(:@description_value, nil)
         subclass.instance_variable_set(:@input_schema_value, nil)
         subclass.instance_variable_set(:@annotations_value, nil)
@@ -44,6 +47,14 @@ module MCP
 
       def input_schema_value
         @input_schema_value || InputSchema.new
+      end
+
+      def title(value = NOT_SET)
+        if value == NOT_SET
+          @title_value
+        else
+          @title_value = value
+        end
       end
 
       def description(value = NOT_SET)
@@ -74,9 +85,10 @@ module MCP
         end
       end
 
-      def define(name: nil, description: nil, input_schema: nil, annotations: nil, &block)
+      def define(name: nil, title: nil, description: nil, input_schema: nil, annotations: nil, &block)
         Class.new(self) do
           tool_name name
+          title title
           description description
           input_schema input_schema
           self.annotations(annotations) if annotations

--- a/test/mcp/prompt_test.rb
+++ b/test/mcp/prompt_test.rb
@@ -111,6 +111,7 @@ module MCP
     test ".define allows definition of simple prompts with a block" do
       prompt = Prompt.define(
         name: "mock_prompt",
+        title: "Mock Prompt",
         description: "a mock prompt for testing",
         arguments: [
           Prompt::Argument.new(name: "test_argument", description: "Test argument", required: true),

--- a/test/mcp/server/transports/stdio_notification_integration_test.rb
+++ b/test/mcp/server/transports/stdio_notification_integration_test.rb
@@ -226,7 +226,8 @@ module MCP
           @server.resources = [
             MCP::Resource.new(
               uri: "https://test_resource.invalid",
-              name: "Test Resource",
+              name: "test-resource",
+              title: "Test Resource",
               description: "A test resource",
               mime_type: "text/plain",
             ),

--- a/test/mcp/tool_test.rb
+++ b/test/mcp/tool_test.rb
@@ -25,8 +25,12 @@ module MCP
     end
 
     test "#to_h returns a hash with name, description, and inputSchema" do
-      tool = Tool.define(name: "mock_tool", description: "a mock tool for testing")
-      assert_equal tool.to_h, { name: "mock_tool", description: "a mock tool for testing", inputSchema: { type: "object" } }
+      tool = Tool.define(
+        name: "mock_tool",
+        title: "Mock Tool",
+        description: "a mock tool for testing",
+      )
+      assert_equal tool.to_h, { name: "mock_tool", title: "Mock Tool", description: "a mock tool for testing", inputSchema: { type: "object" } }
     end
 
     test "#to_h includes annotations when present" do
@@ -109,7 +113,11 @@ module MCP
     end
 
     test ".define allows definition of simple tools with a block" do
-      tool = Tool.define(name: "mock_tool", description: "a mock tool for testing") do |_|
+      tool = Tool.define(
+        name: "mock_tool",
+        title: "Mock Tool",
+        description: "a mock tool for testing",
+      ) do |_|
         Tool::Response.new([{ type: "text", content: "OK" }])
       end
 
@@ -121,9 +129,9 @@ module MCP
     test ".define allows definition of tools with annotations" do
       tool = Tool.define(
         name: "mock_tool",
+        title: "Mock Tool",
         description: "a mock tool for testing",
         annotations: {
-          title: "Mock Tool",
           read_only_hint: true,
         },
       ) do |_|
@@ -131,9 +139,10 @@ module MCP
       end
 
       assert_equal tool.name_value, "mock_tool"
+      assert_equal tool.title, "Mock Tool"
       assert_equal tool.description, "a mock tool for testing"
       assert_equal tool.input_schema, Tool::InputSchema.new
-      assert_equal tool.annotations_value.to_h, { title: "Mock Tool", readOnlyHint: true }
+      assert_equal tool.annotations_value.to_h, { readOnlyHint: true }
     end
 
     # Tests for Tool::Annotations class


### PR DESCRIPTION
This implements the spec change from https://github.com/modelcontextprotocol/modelcontextprotocol/pull/663 to improve user experience by allowing servers to provide a human-friendly names, called "title", for tools, prompts and resources.

## Motivation and Context
There is a [worklog](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/731) to apply the changes to all SDKs but Ruby didn't seem to be listed, so figured I'd go ahead and open a PR!

## How Has This Been Tested?
I've tested the gem locally with each object type from my own Rails MCP server. I also tested both scenarios - with title added vs omitted and both worked as expected.

## Breaking Changes
No, this is an optional field

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
When a title is not added, it will not be included in the response. I assume this is the expected behavior here vs returning a blank title? That's my intuition but curious to hear other's thoughts.
