### PR TITLE
Fix to return a response code 202 if the server accepts JSON-RPC notifications and responses

### DIFF
--- a/lib/mcp/server/transports/streamable_http_transport.rb
+++ b/lib/mcp/server/transports/streamable_http_transport.rb
@@ -108,8 +108,8 @@ module MCP
 
           if body["method"] == "initialize"
             handle_initialization(body_string, body)
-          elsif body["method"] == MCP::Methods::NOTIFICATIONS_INITIALIZED
-            handle_notification_initialized
+          elsif notification?(body) || response?(body)
+            handle_accepted
           else
             handle_regular_request(body_string, session_id)
           end
@@ -168,6 +168,14 @@ module MCP
           [400, { "Content-Type" => "application/json" }, [{ error: "Invalid JSON" }.to_json]]
         end
 
+        def notification?(body)
+          !body["id"] && !!body["method"]
+        end
+
+        def response?(body)
+          !!body["id"] && !body["method"]
+        end
+
         def handle_initialization(body_string, body)
           session_id = SecureRandom.uuid
 
@@ -187,7 +195,7 @@ module MCP
           [200, headers, [response]]
         end
 
-        def handle_notification_initialized
+        def handle_accepted
           [202, {}, []]
         end
 

--- a/test/mcp/server/transports/streamable_http_transport_test.rb
+++ b/test/mcp/server/transports/streamable_http_transport_test.rb
@@ -620,6 +620,32 @@ module MCP
           assert_empty(response[2])
         end
 
+        test "handles POST request with body including JSON-RPC response object and returns with no body" do
+          init_request = create_rack_request(
+            "POST",
+            "/",
+            { "CONTENT_TYPE" => "application/json" },
+            { jsonrpc: "2.0", method: "initialize", id: "init" }.to_json,
+          )
+          init_response = @transport.handle_request(init_request)
+          session_id = init_response[1]["Mcp-Session-Id"]
+
+          request = create_rack_request(
+            "POST",
+            "/",
+            {
+              "CONTENT_TYPE" => "application/json",
+              "HTTP_MCP_SESSION_ID" => session_id,
+            },
+            { jsonrpc: "2.0", result: "success", id: "123" }.to_json,
+          )
+
+          response = @transport.handle_request(request)
+          assert_equal 202, response[0]
+          assert_empty(response[1])
+          assert_empty(response[2])
+        end
+
         private
 
         def create_rack_request(method, path, headers, body = nil)


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
If the server accepts JSON-RPC notifications and responses, it must return an HTTP status code of 202 without a body.

refs
- https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#sending-messages-to-the-server
- https://www.jsonrpc.org/specification

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
- [x] Check existing and added test cases for this case.
- [x] Confirm the server returns 202 when the client sends a notification or response.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
There is a possibility that, if users depend on status code 200.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->

Follow up: https://github.com/modelcontextprotocol/ruby-sdk/issues/111