### PR TITLE
[Docs] Fix broken list rendering of Instrumentation in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -541,12 +541,13 @@ end
 ```
 
 The data contains the following keys:
-`method`: the method called, e.g. `ping`, `tools/list`, `tools/call` etc
-`tool_name`: the name of the tool called
-`prompt_name`: the name of the prompt called
-`resource_uri`: the uri of the resource called
-`error`: if looking up tools/prompts etc failed, e.g. `tool_not_found`
-`duration`: the duration of the call in seconds
+
+- `method`: the method called, e.g. `ping`, `tools/list`, `tools/call` etc
+- `tool_name`: the name of the tool called
+- `prompt_name`: the name of the prompt called
+- `resource_uri`: the uri of the resource called
+- `error`: if looking up tools/prompts etc failed, e.g. `tool_not_found`
+- `duration`: the duration of the call in seconds
 
 `tool_name`, `prompt_name` and `resource_uri` are only populated if a matching handler is registered.
 This is to avoid potential issues with metric cardinality


### PR DESCRIPTION
## Motivation and Context

[Docs] Fix the broken rendering list of Instrumentation in the README

This PR fixes the broken rendering of the following list: https://github.com/modelcontextprotocol/ruby-sdk/tree/v0.2.0?tab=readme-ov-file#instrumentation

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
