### PR TITLE
Add `title` to `serverInfo`

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ class ApplicationController < ActionController::Base
   def index
     server = MCP::Server.new(
       name: "my_server",
+      title: "Example Server Display Name", # WARNING: This is a `Draft` and is not supported in the `Version 2025-06-18 (latest)` specification.
       version: "1.0.0",
       instructions: "Use the tools of this server as a last resort",
       tools: [SomeTool, AnotherTool],

--- a/lib/mcp/server.rb
+++ b/lib/mcp/server.rb
@@ -31,10 +31,11 @@ module MCP
 
     include Instrumentation
 
-    attr_accessor :name, :version, :instructions, :tools, :prompts, :resources, :server_context, :configuration, :capabilities, :transport
+    attr_accessor :name, :title, :version, :instructions, :tools, :prompts, :resources, :server_context, :configuration, :capabilities, :transport
 
     def initialize(
       name: "model_context_protocol",
+      title: nil,
       version: DEFAULT_VERSION,
       instructions: nil,
       tools: [],
@@ -47,6 +48,7 @@ module MCP
       transport: nil
     )
       @name = name
+      @title = title
       @version = version
       @instructions = instructions
       @tools = tools.to_h { |t| [t.name_value, t] }
@@ -218,6 +220,7 @@ module MCP
     def server_info
       @server_info ||= {
         name:,
+        title:,
         version:,
       }
     end

--- a/test/mcp/server_test.rb
+++ b/test/mcp/server_test.rb
@@ -69,6 +69,7 @@ module MCP
 
       @server = Server.new(
         name: @server_name,
+        title: "Example Server Display Name",
         version: "1.2.3",
         instructions: "Optional instructions for the client",
         tools: [@tool, @tool_that_raises],
@@ -140,6 +141,7 @@ module MCP
           },
           serverInfo: {
             name: @server_name,
+            title: "Example Server Display Name",
             version: "1.2.3",
           },
           instructions: "Optional instructions for the client",
@@ -767,6 +769,18 @@ module MCP
 
       response = @server.handle(request)
       assert_equal Configuration::DEFAULT_PROTOCOL_VERSION, response[:result][:protocolVersion]
+    end
+
+    test "server uses default title when not configured" do
+      server = Server.new(name: "test_server")
+      request = {
+        jsonrpc: "2.0",
+        method: "initialize",
+        id: 1,
+      }
+
+      response = server.handle(request)
+      assert_nil response[:result][:serverInfo][:title]
     end
 
     test "server uses default version when not configured" do


### PR DESCRIPTION
## Motivation and Context

Follow-up to #109.

`title` has also been added to `serverInfo` and `clientInfo` by https://github.com/modelcontextprotocol/modelcontextprotocol/pull/663.
Since `clientInfo` is not treated as product code, support is implemented only in `serverInfo`.

See also https://modelcontextprotocol.io/specification/2025-06-18/schema#implementation.

## How Has This Been Tested?

Existing tests have been updated and new tests have been added.

## Breaking Changes

None.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
