### PR TITLE
Fix errors when `title` is not specified

### DIFF
--- a/lib/mcp/server.rb
+++ b/lib/mcp/server.rb
@@ -222,7 +222,7 @@ module MCP
         name:,
         title:,
         version:,
-      }
+      }.compact
     end
 
     def init(request)

--- a/lib/mcp/tool.rb
+++ b/lib/mcp/tool.rb
@@ -19,7 +19,7 @@ module MCP
           title: title_value,
           description: description_value,
           inputSchema: input_schema_value.to_h,
-        }
+        }.compact
         result[:annotations] = annotations_value.to_h if annotations_value
         result
       end

--- a/test/mcp/server_test.rb
+++ b/test/mcp/server_test.rb
@@ -771,7 +771,7 @@ module MCP
       assert_equal Configuration::DEFAULT_PROTOCOL_VERSION, response[:result][:protocolVersion]
     end
 
-    test "server uses default title when not configured" do
+    test "server response does not include title when not configured" do
       server = Server.new(name: "test_server")
       request = {
         jsonrpc: "2.0",
@@ -780,7 +780,7 @@ module MCP
       }
 
       response = server.handle(request)
-      assert_nil response[:result][:serverInfo][:title]
+      refute response[:result][:serverInfo].key?(:title)
     end
 
     test "server uses default version when not configured" do

--- a/test/mcp/tool_test.rb
+++ b/test/mcp/tool_test.rb
@@ -33,6 +33,14 @@ module MCP
       assert_equal({ name: "mock_tool", title: "Mock Tool", description: "a mock tool for testing", inputSchema: { type: "object" } }, tool.to_h)
     end
 
+    test "#to_h does not have `:title` key when title is omitted" do
+      tool = Tool.define(
+        name: "mock_tool",
+        description: "a mock tool for testing",
+      )
+      refute tool.to_h.key?(:title)
+    end
+
     test "#to_h includes annotations when present" do
       tool = TestTool
       expected_annotations = {


### PR DESCRIPTION
## Motivation and Context

Since the optional `title` becomes `title: null` when not provided, the following error occurs. This occurs with Claude Code 1.0.100.

```console
[DEBUG] MCP server "example": Connection failed after 1591ms: [
  {
    "code": "invalid_type",
    "expected": "string",
    "received": "null",
    "path": [
      "serverInfo",
      "title"
    ],
    "message": "Expected string, received null"
  }
]
```

By adding `compact`, the `title` key will be removed if the optional `title` keyword argument is not specified.

## How Has This Been Tested?

Confirmed the fix for the issue in Claude Code and added and updated test cases.

## Breaking Changes

None.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
