### PR TITLE
[Doc] Add example of `define_tool` and `define_protocol`

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ If no exception reporter is configured, a default no-op reporter is used that si
 
 MCP spec includes [Tools](https://modelcontextprotocol.io/specification/2025-06-18/server/tools) which provide functionality to LLM apps.
 
-This gem provides a `MCP::Tool` class that can be used to create tools in two ways:
+This gem provides a `MCP::Tool` class that can be used to create tools in three ways:
 
 1. As a class definition:
 
@@ -415,6 +415,22 @@ tool = MCP::Tool.define(
 end
 ```
 
+3. By using the `ModelContextProtocol::Server#define_tool` method with a block:
+
+```ruby
+server = ModelContextProtocol::Server.new
+server.define_tool(
+  name: "my_tool",
+  description: "This tool performs specific functionality...",
+  annotations: {
+    title: "My Tool",
+    read_only_hint: true
+  }
+) do |args, server_context|
+  Tool::Response.new([{ type: "text", text: "OK" }])
+end
+```
+
 The server_context parameter is the server_context passed into the server and can be used to pass per request information,
 e.g. around authentication state.
 
@@ -434,7 +450,7 @@ Annotations can be set either through the class definition using the `annotation
 
 MCP spec includes [Prompts](https://modelcontextprotocol.io/specification/2025-06-18/server/prompts), which enable servers to define reusable prompt templates and workflows that clients can easily surface to users and LLMs.
 
-The `MCP::Prompt` class provides two ways to create prompts:
+The `MCP::Prompt` class provides three ways to create prompts:
 
 1. As a class definition with metadata:
 
@@ -498,6 +514,37 @@ prompt = MCP::Prompt.define(
       MCP::Prompt::Message.new(
         role: "assistant",
         content: MCP::Content::Text.new(args["message"])
+      )
+    ]
+  )
+end
+```
+
+3. Using the `ModelContextProtocol::Server#define_protocol` method:
+
+```ruby
+server = ModelContextProtocol::Server.new
+server.define_protocol(
+  name: "my_prompt",
+  description: "This prompt performs specific functionality...",
+  arguments: [
+    Prompt::Argument.new(
+      name: "message",
+      description: "Input message",
+      required: true
+    )
+  ]
+) do |args, server_context:|
+  Prompt::Result.new(
+    description: "Response description",
+    messages: [
+      Prompt::Message.new(
+        role: "user",
+        content: Content::Text.new("User message")
+      ),
+      Prompt::Message.new(
+        role: "assistant",
+        content: Content::Text.new(args["message"])
       )
     ]
   )


### PR DESCRIPTION
## Motivation and Context

This PR adds example of `define_tool` and `define_protocol`.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
