### PR TITLE
Combine redundant `any?` calls

### DIFF
--- a/lib/mcp/server.rb
+++ b/lib/mcp/server.rb
@@ -320,10 +320,8 @@ module MCP
 
     def accepts_server_context?(method_object)
       parameters = method_object.parameters
-      accepts_server_context = parameters.any? { |_type, name| name == :server_context }
-      has_kwargs = parameters.any? { |type, _| type == :keyrest }
 
-      accepts_server_context || has_kwargs
+      parameters.any? { |type, name| type == :keyrest || name == :server_context }
     end
 
     def call_tool_with_args(tool, arguments)


### PR DESCRIPTION
## Motivation and Context

Calling `parameters.any?` twice is redundant.

## How Has This Been Tested?

All existing tests pass.

## Breaking Changes

None.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
