### PR TITLE
Remove unused block parameters

### DIFF
--- a/lib/mcp/server.rb
+++ b/lib/mcp/server.rb
@@ -253,7 +253,7 @@ module MCP
     end
 
     def list_tools(request)
-      @tools.map { |_, tool| tool.to_h }
+      @tools.values.map(&:to_h)
     end
 
     def call_tool(request)
@@ -293,7 +293,7 @@ module MCP
     end
 
     def list_prompts(request)
-      @prompts.map { |_, prompt| prompt.to_h }
+      @prompts.values.map(&:to_h)
     end
 
     def get_prompt(request)

--- a/test/mcp/server/transports/stdio_notification_integration_test.rb
+++ b/test/mcp/server/transports/stdio_notification_integration_test.rb
@@ -210,7 +210,7 @@ module MCP
           @server.define_prompt(
             name: "test_prompt",
             description: "Test prompt",
-          ) do |_args, _server_context:|
+          ) do
             MCP::PromptResponse.new(messages: [{ role: "user", content: "Test" }])
           end
 

--- a/test/mcp/server_test.rb
+++ b/test/mcp/server_test.rb
@@ -37,7 +37,7 @@ module MCP
         arguments: [
           Prompt::Argument.new(name: "test_argument", description: "Test argument", required: true),
         ],
-      ) do |_|
+      ) do
         Prompt::Result.new(
           description: "Hello, world!",
           messages: [

--- a/test/mcp/tool_test.rb
+++ b/test/mcp/tool_test.rb
@@ -123,7 +123,7 @@ module MCP
         name: "mock_tool",
         title: "Mock Tool",
         description: "a mock tool for testing",
-      ) do |_|
+      ) do
         Tool::Response.new([{ type: "text", content: "OK" }])
       end
 
@@ -141,7 +141,7 @@ module MCP
           read_only_hint: true,
           title: "Mock Tool",
         },
-      ) do |_|
+      ) do
         Tool::Response.new([{ type: "text", content: "OK" }])
       end
 
@@ -347,7 +347,7 @@ module MCP
         title: "Mock Tool",
         description: "a mock tool for testing",
         output_schema: { properties: { result: { type: "string" } }, required: ["result"] },
-      ) do |_|
+      ) do
         Tool::Response.new([{ type: "text", content: "OK" }])
       end
 


### PR DESCRIPTION
## Motivation and Context

There are some unused block variables. This change removes block parameters that consist solely of unused block parameters.
Where `Hash#values` suffices instead of ignoring unused variables, replace such code with `Hash#values`.

## How Has This Been Tested?

All existing tests pass.

## Breaking Changes

None.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
