### PR TITLE
Add validation to `MCP::Configuration` setters

### DIFF
--- a/lib/mcp/configuration.rb
+++ b/lib/mcp/configuration.rb
@@ -5,20 +5,29 @@ module MCP
     DEFAULT_PROTOCOL_VERSION = "2025-06-18"
     SUPPORTED_PROTOCOL_VERSIONS = [DEFAULT_PROTOCOL_VERSION, "2025-03-26", "2024-11-05"]
 
-    attr_writer :exception_reporter, :instrumentation_callback, :protocol_version, :validate_tool_call_arguments
+    attr_writer :exception_reporter, :instrumentation_callback
 
     def initialize(exception_reporter: nil, instrumentation_callback: nil, protocol_version: nil,
       validate_tool_call_arguments: true)
       @exception_reporter = exception_reporter
       @instrumentation_callback = instrumentation_callback
       @protocol_version = protocol_version
-      if protocol_version && !SUPPORTED_PROTOCOL_VERSIONS.include?(protocol_version)
-        message = "protocol_version must be #{SUPPORTED_PROTOCOL_VERSIONS[0...-1].join(", ")}, or #{SUPPORTED_PROTOCOL_VERSIONS[-1]}"
-        raise ArgumentError, message
+      if protocol_version
+        validate_protocol_version!(protocol_version)
       end
-      unless validate_tool_call_arguments.is_a?(TrueClass) || validate_tool_call_arguments.is_a?(FalseClass)
-        raise ArgumentError, "validate_tool_call_arguments must be a boolean"
-      end
+      validate_value_of_validate_tool_call_arguments!(validate_tool_call_arguments)
+
+      @validate_tool_call_arguments = validate_tool_call_arguments
+    end
+
+    def protocol_version=(protocol_version)
+      validate_protocol_version!(protocol_version)
+
+      @protocol_version = protocol_version
+    end
+
+    def validate_tool_call_arguments=(validate_tool_call_arguments)
+      validate_value_of_validate_tool_call_arguments!(validate_tool_call_arguments)
 
       @validate_tool_call_arguments = validate_tool_call_arguments
     end
@@ -82,6 +91,19 @@ module MCP
     end
 
     private
+
+    def validate_protocol_version!(protocol_version)
+      unless SUPPORTED_PROTOCOL_VERSIONS.include?(protocol_version)
+        message = "protocol_version must be #{SUPPORTED_PROTOCOL_VERSIONS[0...-1].join(", ")}, or #{SUPPORTED_PROTOCOL_VERSIONS[-1]}"
+        raise ArgumentError, message
+      end
+    end
+
+    def validate_value_of_validate_tool_call_arguments!(validate_tool_call_arguments)
+      unless validate_tool_call_arguments.is_a?(TrueClass) || validate_tool_call_arguments.is_a?(FalseClass)
+        raise ArgumentError, "validate_tool_call_arguments must be a boolean"
+      end
+    end
 
     def default_exception_reporter
       @default_exception_reporter ||= ->(exception, server_context) {}

--- a/test/mcp/configuration_test.rb
+++ b/test/mcp/configuration_test.rb
@@ -40,11 +40,21 @@ module MCP
       assert_equal Configuration::DEFAULT_PROTOCOL_VERSION, config.protocol_version
     end
 
-    test "allows setting a custom protocol version" do
+    test "raises ArgumentError when protocol_version is not a supported protocol version" do
       config = Configuration.new
-      custom_version = "2025-03-27"
-      config.protocol_version = custom_version
-      assert_equal custom_version, config.protocol_version
+      exception = assert_raises(ArgumentError) do
+        custom_version = "2025-03-27"
+        config.protocol_version = custom_version
+      end
+      assert_equal("protocol_version must be 2025-06-18, 2025-03-26, or 2024-11-05", exception.message)
+    end
+
+    test "raises ArgumentError when protocol_version is not a boolean value" do
+      config = Configuration.new
+      exception = assert_raises(ArgumentError) do
+        config.validate_tool_call_arguments = "true"
+      end
+      assert_equal("validate_tool_call_arguments must be a boolean", exception.message)
     end
 
     test "merges protocol version from other configuration" do


### PR DESCRIPTION
## Motivation and Context

I noticed through the existing tests that `MCP::Configuration#protocol_version=` allows setting an arbitrary protocol version.

Since the official MCP Ruby SDK is an implementation of the MCP specification, it should not support arbitrary protocol versions. This change adds validation to the setter, consistent with `Configuration#initialize`.

The same validation has also been added to `MCP::Configuration#validate_tool_call_arguments=`.

<!-- Provide a brief summary of your changes -->


<!-- Why is this change needed? What problem does it solve? -->

## How Has This Been Tested?

Test code is being added.

## Breaking Changes

None, because values that don't conform to the specification version are considered invalid.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
