### PR TITLE
Fix some typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,10 +425,10 @@ tool = MCP::Tool.define(
 end
 ```
 
-3. By using the `ModelContextProtocol::Server#define_tool` method with a block:
+3. By using the `MCP::Server#define_tool` method with a block:
 
 ```ruby
-server = ModelContextProtocol::Server.new
+server = MCP::Server.new
 server.define_tool(
   name: "my_tool",
   description: "This tool performs specific functionality...",
@@ -629,11 +629,11 @@ prompt = MCP::Prompt.define(
 end
 ```
 
-3. Using the `ModelContextProtocol::Server#define_protocol` method:
+3. Using the `MCP::Server#define_prompt` method:
 
 ```ruby
-server = ModelContextProtocol::Server.new
-server.define_protocol(
+server = MCP::Server.new
+server.define_prompt(
   name: "my_prompt",
   description: "This prompt performs specific functionality...",
   arguments: [


### PR DESCRIPTION
## Motivation and Context

The `ModelContextProtocol` module name has been renamed to `MCP`, and `define_protocol` appears to be a typo for `define_prompt`.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
