### PR TITLE
Support structuredContent in tool response

### DIFF
--- a/README.md
+++ b/README.md
@@ -555,6 +555,38 @@ MCP spec for the [Output Schema](https://modelcontextprotocol.io/specification/2
 
 The output schema follows standard JSON Schema format and helps ensure consistent data exchange between MCP servers and clients.
 
+### Tool Responses with Structured Content
+
+Tools can return structured data alongside text content using the `structured_content` parameter.
+
+The structured content will be included in the JSON-RPC response as the `structuredContent` field.
+
+```ruby
+class APITool < MCP::Tool
+  description "Get current weather and return structured data"
+
+  def self.call(endpoint:, server_context:)
+    # Call weather API and structure the response
+    api_response = WeatherAPI.fetch(location, units)
+    weather_data = {
+      temperature: api_response.temp,
+      condition: api_response.description,
+      humidity: api_response.humidity_percent
+    }
+
+    output_schema.validate_result(weather_data)
+
+    MCP::Tool::Response.new(
+      [{
+        type: "text",
+        text: weather_data.to_json
+      }],
+      structured_content: weather_data
+    )
+  end
+end
+```
+
 ### Prompts
 
 MCP spec includes [Prompts](https://modelcontextprotocol.io/specification/2025-06-18/server/prompts), which enable servers to define reusable prompt templates and workflows that clients can easily surface to users and LLMs.

--- a/lib/mcp/tool/response.rb
+++ b/lib/mcp/tool/response.rb
@@ -5,9 +5,9 @@ module MCP
     class Response
       NOT_GIVEN = Object.new.freeze
 
-      attr_reader :content
+      attr_reader :content, :structured_content
 
-      def initialize(content, deprecated_error = NOT_GIVEN, error: false)
+      def initialize(content = nil, deprecated_error = NOT_GIVEN, error: false, structured_content: nil)
         if deprecated_error != NOT_GIVEN
           warn("Passing `error` with the 2nd argument of `Response.new` is deprecated. Use keyword argument like `Response.new(content, error: error)` instead.", uplevel: 1)
           error = deprecated_error
@@ -15,6 +15,7 @@ module MCP
 
         @content = content
         @error = error
+        @structured_content = structured_content
       end
 
       def error?
@@ -22,7 +23,7 @@ module MCP
       end
 
       def to_h
-        { content:, isError: error? }.compact
+        { content:, isError: error?, structuredContent: @structured_content }.compact
       end
     end
   end

--- a/test/mcp/tool/response_test.rb
+++ b/test/mcp/tool/response_test.rb
@@ -38,6 +38,19 @@ module MCP
         refute response.error?
       end
 
+      test "#initialize with content and structuredContent" do
+        content = [{
+          type: "text",
+          text: "{\"code\":401,\"message\":\"Unauthorized\"}",
+        }]
+        structured_content = { code: 401, message: "Unauthorized" }
+        response = Response.new(content, structured_content: structured_content)
+
+        assert_equal content, response.content
+        assert_equal structured_content, response.structured_content
+        refute response.error?
+      end
+
       test "#error? for a standard response" do
         response = Response.new(nil, error: false)
         refute response.error?
@@ -71,6 +84,32 @@ module MCP
         assert_equal [:content, :isError].sort, actual.keys.sort
         assert_equal content, actual[:content]
         assert actual[:isError]
+      end
+
+      test "#to_h for a standard response with content and structured content" do
+        content = [{
+          type: "text",
+          text: "{\"code\":401,\"message\":\"Unauthorized\"}",
+        }]
+        structured_content = { code: 401, message: "Unauthorized" }
+        response = Response.new(content, structured_content: structured_content)
+        actual = response.to_h
+
+        assert_equal [:content, :isError, :structuredContent].sort, actual.keys.sort
+        assert_equal content, actual[:content]
+        assert_equal structured_content, actual[:structuredContent]
+        refute actual[:isError]
+      end
+
+      test "#to_h for a standard response with structured content only" do
+        structured_content = { code: 401, message: "Unauthorized" }
+        response = Response.new(structured_content: structured_content)
+        actual = response.to_h
+
+        assert_equal [:isError, :structuredContent].sort, actual.keys.sort
+        assert_nil actual[:content]
+        assert_equal structured_content, actual[:structuredContent]
+        refute actual[:isError]
       end
     end
   end


### PR DESCRIPTION
This PR enables the inclusion of `structuredContent` within tool call responses.

```ruby
result = get_some_result_object()

response = MCP::Tool::Response.new(structured_content: result)
```

Or, to conform with the spec's [suggestion](https://modelcontextprotocol.io/specification/2025-06-18/server/tools#structured-content) about backward compatibility, both `content` and `structured_content` may be provided:

```ruby
response = MCP::Tool::Response.new(
  [{
    type: "text",
    text: result.to_json
  }],
  structured_content: result
)
```

## Motivation and Context

Currently an `MCP::Tool` which declares an `output_schema` but does _not_ provide `structuredContent` in its response is entirely incompatible with the many MCP clients that are built with the official Python SDK:

See: [modelcontextprotocol/python-sdk/src/mcp/client/session.py](https://github.com/modelcontextprotocol/python-sdk/blob/71889d7387f070cd872cab7c9aa3d1ff1fa5a5d2/src/mcp/client/session.py#L310-L312) 

In order to make Ruby SDK MCP servers useable with such clients we need to support `structuredContent` in conformance with the spec for `CallToolResult`:

See: https://modelcontextprotocol.io/specification/2025-06-18/schema#calltoolresult
See: https://modelcontextprotocol.io/specification/2025-06-18/server/tools#structured-content

@honzasterba had kindly submitted a similar PR #81 — this PR follows @koic's [suggestion](https://github.com/modelcontextprotocol/ruby-sdk/pull/81#issuecomment-3218512276) there.

## How Has This Been Tested?

In addition to the unit tests, I have field tested this in an MCP server that utilizes this change in:

- ✅ The **MCP Inspector** dev tool, which both validates the `structuredContent` against the `output_schema` and confirms that the `structuredContent` matches the serialized `content` 
- ✅ An agent built with [**Fast Agent**](https://fast-agent.ai), a framework which makes use of the official Python SDK cited above. This was failing before and motivated this PR. It now works, after this change 
- ✅ **Claude Code**, which does not require the `structuredContent`, so was fine before and after this change  🤷🏽

## Breaking Changes

None. 

The tool response can be constructed as before, or in the new style:

```ruby
# ✅ still works
MCP::Tool::Response.new([{
  type: "text",
  text: result.to_json
}]) 

# ✅ possible now
MCP::Tool::Response.new(structured_content: result) 

# ✅ or both, for backwards compatibility 
MCP::Tool::Response.new(
  [{
    type: "text",
    text: result.to_json
  }],
  structured_content: result
) 
```

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

I have not added documentation yet, but if this PR seems likely to be accepted I can definitely do so!