### PR TITLE
[client] Change call_tool method to return the full tool response to help get structuredContent

### DIFF
--- a/lib/mcp/client.rb
+++ b/lib/mcp/client.rb
@@ -44,28 +44,27 @@ module MCP
       end || []
     end
 
-    # Calls a tool via the transport layer.
+    # Calls a tool via the transport layer and returns the full response from the server.
     #
     # @param tool [MCP::Client::Tool] The tool to be called.
     # @param arguments [Object, nil] The arguments to pass to the tool.
-    # @return [Object] The result of the tool call, as returned by the transport.
+    # @return [Hash] The full JSON-RPC response from the transport.
     #
     # @example
     #   tool = client.tools.first
-    #   result = client.call_tool(tool: tool, arguments: { foo: "bar" })
+    #   response = client.call_tool(tool: tool, arguments: { foo: "bar" })
+    #   structured_content = response.dig("result", "structuredContent")
     #
     # @note
     #   The exact requirements for `arguments` are determined by the transport layer in use.
     #   Consult the documentation for your transport (e.g., MCP::Client::HTTP) for details.
     def call_tool(tool:, arguments: nil)
-      response = transport.send_request(request: {
+      transport.send_request(request: {
         jsonrpc: JsonRpcHandler::Version::V2_0,
         id: request_id,
         method: "tools/call",
         params: { name: tool.name, arguments: arguments },
       })
-
-      response.dig("result", "content")
     end
 
     private

--- a/test/mcp/client_test.rb
+++ b/test/mcp/client_test.rb
@@ -53,8 +53,9 @@ module MCP
 
       client = Client.new(transport: transport)
       result = client.call_tool(tool: tool, arguments: arguments)
+      content = result.dig("result", "content")
 
-      assert_equal("result", result)
+      assert_equal("result", content)
     end
   end
 end


### PR DESCRIPTION
⚠️ Change `call_tool` in `Client` to return the full response.

## Motivation and Context
Helps get `structuredContent` and errors.

More like Python does:
https://github.com/modelcontextprotocol/python-sdk/blob/3e798bfc01856df711b921f7f3b55379fbd087e4/src/mcp/client/session.py#L279

## How Has This Been Tested?
Unit test

## Breaking Changes
⚠️ YES!

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
