### PR TITLE
Set default `content` to an empty array instead of `nil`

### DIFF
--- a/lib/mcp/tool/response.rb
+++ b/lib/mcp/tool/response.rb
@@ -13,7 +13,7 @@ module MCP
           error = deprecated_error
         end
 
-        @content = content
+        @content = content || []
         @error = error
         @structured_content = structured_content
       end

--- a/test/mcp/tool/response_test.rb
+++ b/test/mcp/tool/response_test.rb
@@ -101,13 +101,24 @@ module MCP
         refute actual[:isError]
       end
 
+      test "#to_h for a standard response with nil content and structured content" do
+        structured_content = { code: 401, message: "Unauthorized" }
+        response = Response.new(nil, structured_content: structured_content)
+        actual = response.to_h
+
+        assert_equal [:content, :isError, :structuredContent], actual.keys
+        assert_empty actual[:content]
+        assert_equal structured_content, actual[:structuredContent]
+        refute actual[:isError]
+      end
+
       test "#to_h for a standard response with structured content only" do
         structured_content = { code: 401, message: "Unauthorized" }
         response = Response.new(structured_content: structured_content)
         actual = response.to_h
 
-        assert_equal [:isError, :structuredContent], actual.keys
-        assert_nil actual[:content]
+        assert_equal [:content, :isError, :structuredContent], actual.keys
+        assert_empty actual[:content]
         assert_equal structured_content, actual[:structuredContent]
         refute actual[:isError]
       end


### PR DESCRIPTION
## Motivation and Context

Follow-up to https://github.com/modelcontextprotocol/ruby-sdk/pull/147.

According to the specification schema, `content` is not optional and therefore cannot be omitted:

```typescript
interface CallToolResult {
  _meta?: { [key: string]: unknown };
  content: ContentBlock[];
  isError?: boolean;
  structuredContent?: { [key: string]: unknown };
  [key: string]: unknown;
}
```

https://modelcontextprotocol.io/specification/2025-06-18/schema#calltoolresult

Instead of `nil`, an empty array is set as the default value.

There may be a better value for `content`, but at the very least it should not be missing.

## How Has This Been Tested?

The related test code has been updated.

## Breaking Changes

#147 is unreleased, there are no breaking changes on the main branch.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
