### PR TITLE
Remove unnecessary transport requires

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,6 @@ If you want to build a local command-line application, you can use the stdio tra
 
 ```ruby
 require "mcp"
-require "mcp/server/transports/stdio_transport"
 
 # Create a simple tool
 class ExampleTool < MCP::Tool

--- a/examples/http_server.rb
+++ b/examples/http_server.rb
@@ -2,7 +2,6 @@
 
 $LOAD_PATH.unshift(File.expand_path("../lib", __dir__))
 require "mcp"
-require "mcp/server/transports/streamable_http_transport"
 require "rack"
 require "rackup"
 require "json"

--- a/examples/stdio_server.rb
+++ b/examples/stdio_server.rb
@@ -2,7 +2,6 @@
 
 $LOAD_PATH.unshift(File.expand_path("../lib", __dir__))
 require "mcp"
-require "mcp/server/transports/stdio_transport"
 
 # Create a simple tool
 class ExampleTool < MCP::Tool

--- a/examples/streamable_http_server.rb
+++ b/examples/streamable_http_server.rb
@@ -2,7 +2,6 @@
 
 $LOAD_PATH.unshift(File.expand_path("../lib", __dir__))
 require "mcp"
-require "mcp/server/transports/streamable_http_transport"
 require "rack"
 require "rackup"
 require "json"


### PR DESCRIPTION
## Motivation and Context

The transports are already required by `require 'mcp'`: https://github.com/modelcontextprotocol/ruby-sdk/blob/v0.3.0/lib/mcp.rb#L16-L17

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
