### PR TITLE
[Doc] Fix incorrect example code in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Notifications follow the JSON-RPC 2.0 specification and use these method names:
 
 ```ruby
 server = MCP::Server.new(name: "my_server")
-transport = MCP::Transports::HTTP.new(server)
+transport = MCP::Server::Transports::StreamableHTTPTransport.new(server)
 server.transport = transport
 
 # When tools change, notify clients


### PR DESCRIPTION
## Motivation and Context

Follow-up to https://github.com/modelcontextprotocol/ruby-sdk/pull/33.

A `NameError` occurs because `MCP::Transports::HTTP` does not exist. The correct constant is `MCP::Server::Transports::StreamableHTTPTransport`.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
