### PR TITLE
[Doc] Mention `resources/list` and `resources/read` in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -826,8 +826,10 @@ The `MCP::Client` class provides an interface for interacting with MCP servers.
 
 This class supports:
 
-- Tool listing via the `tools/list` method
-- Tool invocation via the `tools/call` method
+- Tool listing via the `tools/list` method (`MCP::Client#tools`)
+- Tool invocation via the `tools/call` method (`MCP::Client#call_tools`)
+- Resource listing via the `resources/list` method (`MCP::Client#resources`)
+- Resource reading via the `resources/read` method (`MCP::Client#read_resources`)
 - Automatic JSON-RPC 2.0 message formatting
 - UUID request ID generation
 


### PR DESCRIPTION
## Motivation and Context

Follow-up to https://github.com/modelcontextprotocol/ruby-sdk/pull/160

This PR mentions `resources/list` and `resources/read` in the README.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
