### PR TITLE
Fix test for empty resources response of client

### DIFF
--- a/test/mcp/client_test.rb
+++ b/test/mcp/client_test.rb
@@ -84,6 +84,18 @@ module MCP
       assert_equal("file:///path/to/resource2", resources.last["uri"])
     end
 
+    def test_resources_returns_empty_array_when_no_resources
+      transport = mock
+      mock_response = { "result" => { "resources" => [] } }
+
+      transport.expects(:send_request).returns(mock_response).once
+
+      client = Client.new(transport: transport)
+      resources = client.resources
+
+      assert_empty(resources)
+    end
+
     def test_read_resource_sends_request_to_transport_and_returns_contents
       transport = mock
       uri = "file:///path/to/resource.txt"
@@ -128,18 +140,6 @@ module MCP
       contents = client.read_resource(uri: uri)
 
       assert_empty(contents)
-    end
-
-    def test_resources_returns_empty_array_when_no_resources
-      transport = mock
-      mock_response = { "result" => {} }
-
-      transport.expects(:send_request).returns(mock_response).once
-
-      client = Client.new(transport: transport)
-      resources = client.resources
-
-      assert_empty(resources)
     end
   end
 end


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

Update `test_resources_returns_empty_array_when_no_resources` to use correct mock response format with empty resources array instead of empty result object. 
Also reorder test to group with other resources tests.

Follow up: https://github.com/modelcontextprotocol/ruby-sdk/pull/160

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Check existing and added test cases for this case.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
None

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
