### PR TITLE
Add `prompts/list` and `prompts/get` support to client

### DIFF
--- a/README.md
+++ b/README.md
@@ -830,6 +830,8 @@ This class supports:
 - Tool invocation via the `tools/call` method (`MCP::Client#call_tools`)
 - Resource listing via the `resources/list` method (`MCP::Client#resources`)
 - Resource reading via the `resources/read` method (`MCP::Client#read_resources`)
+- Prompt listing via the `prompts/list` method (`MCP::Client#prompts`)
+- Prompt retrieval via the `prompts/get` method (`MCP::Client#get_prompt`)
 - Automatic JSON-RPC 2.0 message formatting
 - UUID request ID generation
 

--- a/lib/mcp/client.rb
+++ b/lib/mcp/client.rb
@@ -58,6 +58,20 @@ module MCP
       response.dig("result", "resources") || []
     end
 
+    # Returns the list of prompts available from the server.
+    # Each call will make a new request – the result is not cached.
+    #
+    # @return [Array<Hash>] An array of available prompts.
+    def prompts
+      response = transport.send_request(request: {
+        jsonrpc: JsonRpcHandler::Version::V2_0,
+        id: request_id,
+        method: "prompts/list",
+      })
+
+      response.dig("result", "prompts") || []
+    end
+
     # Calls a tool via the transport layer and returns the full response from the server.
     #
     # @param tool [MCP::Client::Tool] The tool to be called.
@@ -94,6 +108,21 @@ module MCP
       })
 
       response.dig("result", "contents") || []
+    end
+
+    # Gets a prompt from the server by name and returns its details.
+    #
+    # @param name [String] The name of the prompt to get.
+    # @return [Hash] A hash containing the prompt details.
+    def get_prompt(name:)
+      response = transport.send_request(request: {
+        jsonrpc: JsonRpcHandler::Version::V2_0,
+        id: request_id,
+        method: "prompts/get",
+        params: { name: name },
+      })
+
+      response.fetch("result", {})
     end
 
     private


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

This commit adds two new methods to `MCP::Client`:
- prompts: Lists available prompts from the server via `prompts/list`
- get_prompt: Retrieves a specific prompt by name via `prompts/get`

Both methods follow the same pattern as [the existing resources support](https://github.com/modelcontextprotocol/ruby-sdk/pull/160), including comprehensive test coverage and README documentation updates.

ref. https://github.com/modelcontextprotocol/modelcontextprotocol/blob/main/docs/specification/2025-03-26/server/prompts.mdx#protocol-messages

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Check existing and added test cases for this case.
https://github.com/modelcontextprotocol/ruby-sdk/pull/163/files#diff-7daf60c70888017747b710518764087efc6171bb2f5419506cf21a8ac7ef4a5a

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
None

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
