### PR TITLE
Fix tool error handling to follow MCP spec

### DIFF
--- a/test/mcp/server_context_test.rb
+++ b/test/mcp/server_context_test.rb
@@ -152,9 +152,10 @@ module MCP
 
       response = server_no_context.handle(request)
 
-      assert response[:error]
-      # The error is wrapped as "Internal error calling tool..."
-      assert_equal "Internal error", response[:error][:message]
+      assert_nil response[:error], "Expected no JSON-RPC error"
+      assert response[:result][:isError]
+      assert_equal "text", response[:result][:content][0][:type]
+      assert_match(/Internal error calling tool tool_with_required_context: /, response[:result][:content][0][:text])
     end
 
     test "call_tool_with_args correctly detects server_context parameter presence" do


### PR DESCRIPTION
  Tool execution errors now return successful responses with isError: true
  instead of JSON-RPC protocol errors, per the MCP specification.

## Motivation and Context
This allows clients to distinguish between protocol-level errors and
tool execution errors, providing better error context.

Fixes #159


## How Has This Been Tested?
Updated unit tests to support new error behavior. All existing tests passing. 

## Breaking Changes
If client libs are parsing the error message for the specific tool call error, then they will likely get a parser error due to the change of the error structure. 

Current behavior:
 ```
     {
       "jsonrpc": "2.0",
       "id": 4,
       "error": {
         "code": -32603,
         "message": "Internal error",
         "data": "Internal error calling tool fetch_weather_data"
       }
     }
```

Updated behavior (matches spec and readme):

```
     {
       "jsonrpc": "2.0",
       "id": 4,
       "result": {
         "content": [{
           "type": "text",
           "text": "Internal error calling tool fetch_weather_data"
         }],
         "isError": true
       }
     }
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x ] I have added or updated documentation as needed
