### PR TITLE
Remove redundant `rack` gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,6 @@ gem "rubocop-rake", require: false
 gem "rubocop-shopify", require: false
 
 gem "puma", ">= 5.0.0"
-gem "rack", ">= 2.0.0"
 gem "rackup", ">= 2.1.0"
 
 gem "activesupport"

--- a/examples/http_server.rb
+++ b/examples/http_server.rb
@@ -2,7 +2,6 @@
 
 $LOAD_PATH.unshift(File.expand_path("../lib", __dir__))
 require "mcp"
-require "rack"
 require "rackup"
 require "json"
 require "logger"

--- a/examples/streamable_http_server.rb
+++ b/examples/streamable_http_server.rb
@@ -2,7 +2,6 @@
 
 $LOAD_PATH.unshift(File.expand_path("../lib", __dir__))
 require "mcp"
-require "rack"
 require "rackup"
 require "json"
 require "logger"


### PR DESCRIPTION
## Motivation and Context

This PR removes the existing `rack` dependency.
`rack` is a dependency of `rackup`.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
