### PR TITLE
[Doc] Fix incorrect schema name

### DIFF
--- a/README.md
+++ b/README.md
@@ -551,7 +551,7 @@ Output schema may also describe an array of objects:
 class WeatherTool < MCP::Tool
   output_schema(
     type: "array",
-    item: {
+    items: {
       properties: {
         temperature: { type: "number" },
         condition: { type: "string" },


### PR DESCRIPTION
## Motivation and Context

This PR fixes an incorrect schema name.

The test code already uses `items:`.
https://github.com/modelcontextprotocol/ruby-sdk/blob/v0.4.0/test/mcp/tool/output_schema_test.rb#L135-L141

Fixes #170.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
