### PR TITLE
Replace 'rackup' with 'rack' in server file

### DIFF
--- a/examples/streamable_http_server.rb
+++ b/examples/streamable_http_server.rb
@@ -2,7 +2,7 @@
 
 $LOAD_PATH.unshift(File.expand_path("../lib", __dir__))
 require "mcp"
-require "rackup"
+require "rack"
 require "json"
 require "logger"
 
@@ -168,4 +168,4 @@ puts <<~MESSAGE
 MESSAGE
 
 # Start the server
-Rackup::Handler.get("puma").run(rack_app, Port: 9393, Host: "localhost")
+Rack::Handler.get("puma").run(rack_app, Port: 9393, Host: "localhost")


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
Running this example with Ruby 3.4.5 the following does not work:

```ruby
Rackup::Handler.get("puma").run(rack_app, Port: 9393, Host: "0.0.0.0")
```
It returns the following error message:
`uninitialized constant Rackup::Handler (NameError)`

To resolve this I just required Rack and changed Rackup to Rack.  Then things worked fine.



## How Has This Been Tested?
I was running this in development mode to help me understand the use of the gem and ran into this issue.

## Breaking Changes
There shouldn't be any breaking changes

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
