### PR TITLE
Add Elicitation skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,11 +151,12 @@ Set `stateless: true` in `MCP::Server::Transports::StreamableHTTPTransport.new` 
 transport = MCP::Server::Transports::StreamableHTTPTransport.new(server, stateless: true)
 ```
 
-### Unsupported Features ( to be implemented in future versions )
+### Unsupported Features (to be implemented in future versions)
 
 - Log Level
 - Resource subscriptions
 - Completions
+- Elicitation
 
 ### Usage
 

--- a/lib/mcp/methods.rb
+++ b/lib/mcp/methods.rb
@@ -21,6 +21,7 @@ module MCP
 
     ROOTS_LIST = "roots/list"
     SAMPLING_CREATE_MESSAGE = "sampling/createMessage"
+    ELICITATION_CREATE = "elicitation/create"
 
     # Notification methods
     NOTIFICATIONS_INITIALIZED = "notifications/initialized"
@@ -76,6 +77,8 @@ module MCP
           require_capability!(method, capabilities, :roots, :listChanged)
         when SAMPLING_CREATE_MESSAGE
           require_capability!(method, capabilities, :sampling)
+        when ELICITATION_CREATE
+          require_capability!(method, capabilities, :elicitation)
         when INITIALIZE, PING, NOTIFICATIONS_INITIALIZED, NOTIFICATIONS_PROGRESS, NOTIFICATIONS_CANCELLED
           # No specific capability required for initialize, ping, progress or cancelled
         end

--- a/lib/mcp/server.rb
+++ b/lib/mcp/server.rb
@@ -80,6 +80,7 @@ module MCP
         Methods::RESOURCES_UNSUBSCRIBE => ->(_) {},
         Methods::COMPLETION_COMPLETE => ->(_) {},
         Methods::LOGGING_SET_LEVEL => ->(_) {},
+        Methods::ELICITATION_CREATE => ->(_) {},
       }
       @transport = transport
     end

--- a/test/mcp/methods_test.rb
+++ b/test/mcp/methods_test.rb
@@ -74,6 +74,8 @@ module MCP
 
     ensure_capability_raises_error_for Methods::SAMPLING_CREATE_MESSAGE, required_capability_name: "sampling"
 
+    ensure_capability_raises_error_for Methods::ELICITATION_CREATE, required_capability_name: "elicitation"
+
     # Methods and notifications of both server and client
     ensure_capability_does_not_raise_for Methods::PING
     ensure_capability_does_not_raise_for Methods::NOTIFICATIONS_PROGRESS


### PR DESCRIPTION
## Motivation and Context

The MCP 2025-06-18 specification includes a feature called Elicitation:
https://modelcontextprotocol.io/specification/2025-06-18/client/elicitation

Like Log Level, an implementation is expected to be provided in the near future. This PR adds Elicitation as a skeleton implementation for now.

## How Has This Been Tested?

The added test passes.

## Breaking Changes

No breaking changes.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
