### PR TITLE
[Doc] Fix incorrect examples in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,7 +434,7 @@ tool = MCP::Tool.define(
     read_only_hint: true,
     title: "My Tool"
   }
-) do |args, server_context|
+) do |args, server_context:|
   MCP::Tool::Response.new([{ type: "text", text: "OK" }])
 end
 ```
@@ -450,7 +450,7 @@ server.define_tool(
     title: "My Tool",
     read_only_hint: true
   }
-) do |args, server_context|
+) do |args, server_context:|
   Tool::Response.new([{ type: "text", text: "OK" }])
 end
 ```
@@ -540,7 +540,7 @@ tool = MCP::Tool.define(
     },
     required: ["mean", "median", "count"]
   }
-) do |args, server_context|
+) do |args, server_context:|
   # Calculate statistics and validate against schema
   MCP::Tool::Response.new([{ type: "text", text: "Statistics calculated" }])
 end


### PR DESCRIPTION
## Motivation and Context

This PR fixes incorrect examples in README.md. The block variable could be removed if it is unused, but when presenting an example `:server_context` should still be shown as a keyword argument.

Fixes #185.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
