### PR TITLE
Add support for the optional `websiteUrl` parameter in `serverInfo`

### DIFF
--- a/lib/mcp/server.rb
+++ b/lib/mcp/server.rb
@@ -31,13 +31,14 @@ module MCP
 
     include Instrumentation
 
-    attr_accessor :description, :name, :title, :version, :instructions, :tools, :prompts, :resources, :server_context, :configuration, :capabilities, :transport
+    attr_accessor :description, :name, :title, :version, :website_url, :instructions, :tools, :prompts, :resources, :server_context, :configuration, :capabilities, :transport
 
     def initialize(
       description: nil,
       name: "model_context_protocol",
       title: nil,
       version: DEFAULT_VERSION,
+      website_url: nil,
       instructions: nil,
       tools: [],
       prompts: [],
@@ -52,6 +53,7 @@ module MCP
       @name = name
       @title = title
       @version = version
+      @website_url = website_url
       @instructions = instructions
       @tools = tools.to_h { |t| [t.name_value, t] }
       @prompts = prompts.to_h { |p| [p.name_value, p] }
@@ -185,8 +187,8 @@ module MCP
       end
 
       if @configuration.protocol_version <= "2025-03-26"
-        if server_info.key?(:title)
-          message = "Error occurred in server_info. `title` is not supported in protocol version 2025-03-26 or earlier"
+        if server_info.key?(:title) || server_info.key?(:websiteUrl)
+          message = "Error occurred in server_info. `title` or `website_url` are not supported in protocol version 2025-03-26 or earlier"
           raise ArgumentError, message
         end
 
@@ -268,6 +270,7 @@ module MCP
         name:,
         title:,
         version:,
+        websiteUrl: website_url,
       }.compact
     end
 

--- a/test/mcp/server_test.rb
+++ b/test/mcp/server_test.rb
@@ -781,7 +781,22 @@ module MCP
       assert_equal Configuration::LATEST_STABLE_PROTOCOL_VERSION, response[:result][:protocolVersion]
     end
 
-    test "server response does not include title when not configured" do
+    test "server response does not include optional parameters when configured" do
+      server = Server.new(title: "Example Server Display Name", name: "test_server", website_url: "https://example.com")
+      request = {
+        jsonrpc: "2.0",
+        method: "initialize",
+        id: 1,
+      }
+
+      response = server.handle(request)
+      server_info = response[:result][:serverInfo]
+
+      assert_equal("Example Server Display Name", server_info[:title])
+      assert_equal("https://example.com", server_info[:websiteUrl])
+    end
+
+    test "server response does not include optional parameters when not configured" do
       server = Server.new(name: "test_server")
       request = {
         jsonrpc: "2.0",
@@ -791,6 +806,7 @@ module MCP
 
       response = server.handle(request)
       refute response[:result][:serverInfo].key?(:title)
+      refute response[:result][:serverInfo].key?(:website_url)
     end
 
     test "server uses default version when not configured" do
@@ -875,7 +891,16 @@ module MCP
       exception = assert_raises(ArgumentError) do
         Server.new(name: "test_server", title: "Example Server Display Name", configuration: configuration)
       end
-      assert_equal("Error occurred in server_info. `title` is not supported in protocol version 2025-03-26 or earlier", exception.message)
+      assert_equal("Error occurred in server_info. `title` or `website_url` are not supported in protocol version 2025-03-26 or earlier", exception.message)
+    end
+
+    test "raises error if `website_url` of `server_info` is used with protocol version 2025-03-26" do
+      configuration = Configuration.new(protocol_version: "2025-03-26")
+
+      exception = assert_raises(ArgumentError) do
+        Server.new(name: "test_server", website_url: "https://example.com", configuration: configuration)
+      end
+      assert_equal("Error occurred in server_info. `title` or `website_url` are not supported in protocol version 2025-03-26 or earlier", exception.message)
     end
 
     test "raises error if `title` of tool is used with protocol version 2025-03-26" do


### PR DESCRIPTION
## Motivation and Context

This PR adds support for the optional `websiteUrl` parameter in `serverInfo`. This parameter has been supported since the 2025-11-25 MCP specification.

This PR also implements part of https://github.com/modelcontextprotocol/ruby-sdk/issues/127.

## How Has This Been Tested?

The tests have been updated and are now passing.

## Breaking Changes

None.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
