### PR TITLE
[Docs] Update specification URL to `latest`

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ transport = MCP::Server::Transports::StreamableHTTPTransport.new(server, statele
 #### Rails Controller
 
 When added to a Rails controller on a route that handles POST requests, your server will be compliant with non-streaming
-[Streamable HTTP](https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#streamable-http) transport
+[Streamable HTTP](https://modelcontextprotocol.io/specification/latest/basic/transports#streamable-http) transport
 requests.
 
 You can use the `Server#handle_json` method to handle requests.
@@ -383,7 +383,7 @@ If no exception reporter is configured, a default no-op reporter is used that si
 
 ### Tools
 
-MCP spec includes [Tools](https://modelcontextprotocol.io/specification/2025-06-18/server/tools) which provide functionality to LLM apps.
+MCP spec includes [Tools](https://modelcontextprotocol.io/specification/latest/server/tools) which provide functionality to LLM apps.
 
 This gem provides a `MCP::Tool` class that can be used to create tools in three ways:
 
@@ -581,7 +581,7 @@ end
 Please note: in this case, you must provide `type: "array"`. The default type
 for output schemas is `object`.
 
-MCP spec for the [Output Schema](https://modelcontextprotocol.io/specification/2025-06-18/server/tools#output-schema) specifies that:
+MCP spec for the [Output Schema](https://modelcontextprotocol.io/specification/latest/server/tools#output-schema) specifies that:
 
 - **Server Validation**: Servers MUST provide structured results that conform to the output schema
 - **Client Validation**: Clients SHOULD validate structured results against the output schema
@@ -624,7 +624,7 @@ end
 
 ### Prompts
 
-MCP spec includes [Prompts](https://modelcontextprotocol.io/specification/2025-06-18/server/prompts), which enable servers to define reusable prompt templates and workflows that clients can easily surface to users and LLMs.
+MCP spec includes [Prompts](https://modelcontextprotocol.io/specification/latest/server/prompts), which enable servers to define reusable prompt templates and workflows that clients can easily surface to users and LLMs.
 
 The `MCP::Prompt` class provides three ways to create prompts:
 
@@ -787,7 +787,7 @@ This is to avoid potential issues with metric cardinality
 
 ### Resources
 
-MCP spec includes [Resources](https://modelcontextprotocol.io/specification/2025-06-18/server/resources).
+MCP spec includes [Resources](https://modelcontextprotocol.io/specification/latest/server/resources).
 
 ### Reading Resources
 

--- a/test/mcp/server_test.rb
+++ b/test/mcp/server_test.rb
@@ -80,7 +80,7 @@ module MCP
       )
     end
 
-    # https://modelcontextprotocol.io/specification/2025-06-18/basic/utilities/ping#behavior-requirements
+    # https://modelcontextprotocol.io/specification/latest/basic/utilities/ping#behavior-requirements
     test "#handle ping request returns empty response" do
       request = {
         jsonrpc: "2.0",


### PR DESCRIPTION
## Motivation and Context

This PR updates the specification URL to `latest`. This change avoids the need to update the URL whenever a new protocol version is released. The `latest` path redirects to the latest protocol version.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
