### PR TITLE
Default to the latest stable protocol version

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,7 +349,8 @@ configuration = MCP::Configuration.new(protocol_version: "2024-11-05")
 MCP::Server.new(name: "test_server", configuration: configuration)
 ```
 
-If no protocol version is specified, the [Draft version](https://modelcontextprotocol.io/specification/draft) will be applied by default.
+If no protocol version is specified, the latest stable version will be applied by default.
+The latest stable version includes new features from the [draft version](https://modelcontextprotocol.io/specification/draft).
 
 This will make all new server instances use the specified protocol version instead of the default version. The protocol version can be reset to the default by setting it to `nil`:
 

--- a/lib/mcp/configuration.rb
+++ b/lib/mcp/configuration.rb
@@ -2,10 +2,8 @@
 
 module MCP
   class Configuration
-    # DRAFT-2025-v3 is the latest draft protocol version:
-    # https://github.com/modelcontextprotocol/modelcontextprotocol/blob/14ec41c/schema/draft/schema.ts#L15
-    DRAFT_PROTOCOL_VERSION = "DRAFT-2025-v3"
-    SUPPORTED_STABLE_PROTOCOL_VERSIONS = ["2025-06-18", "2025-03-26", "2024-11-05"]
+    LATEST_STABLE_PROTOCOL_VERSION = "2025-06-18"
+    SUPPORTED_STABLE_PROTOCOL_VERSIONS = [LATEST_STABLE_PROTOCOL_VERSION, "2025-03-26", "2024-11-05"]
 
     attr_writer :exception_reporter, :instrumentation_callback
 
@@ -35,7 +33,7 @@ module MCP
     end
 
     def protocol_version
-      @protocol_version || DRAFT_PROTOCOL_VERSION
+      @protocol_version || LATEST_STABLE_PROTOCOL_VERSION
     end
 
     def protocol_version?

--- a/test/mcp/configuration_test.rb
+++ b/test/mcp/configuration_test.rb
@@ -38,18 +38,19 @@ module MCP
     # https://github.com/modelcontextprotocol/modelcontextprotocol/blob/14ec41c/schema/draft/schema.ts#L15
     test "initializes with default protocol version" do
       config = Configuration.new
-      assert_equal Configuration::DRAFT_PROTOCOL_VERSION, config.protocol_version
+      assert_equal Configuration::LATEST_STABLE_PROTOCOL_VERSION, config.protocol_version
     end
 
     test "uses the draft protocol version when protocol_version is set to nil" do
       config = Configuration.new(protocol_version: nil)
-      assert_equal Configuration::DRAFT_PROTOCOL_VERSION, config.protocol_version
+      assert_equal Configuration::LATEST_STABLE_PROTOCOL_VERSION, config.protocol_version
     end
 
     test "raises ArgumentError when setting the draft protocol version" do
       exception = assert_raises(ArgumentError) do
-        # To use the draft version externally, either omit `protocol_version` or set it to nil.
-        Configuration.new(protocol_version: Configuration::DRAFT_PROTOCOL_VERSION)
+        # DRAFT-2025-v3 is the latest draft protocol version:
+        # https://github.com/modelcontextprotocol/modelcontextprotocol/blob/14ec41c/schema/draft/schema.ts#L15
+        Configuration.new(protocol_version: "DRAFT-2025-v3")
       end
 
       assert_equal("protocol_version must be 2025-06-18, 2025-03-26, or 2024-11-05", exception.message)

--- a/test/mcp/server/transports/streamable_http_transport_test.rb
+++ b/test/mcp/server/transports/streamable_http_transport_test.rb
@@ -81,7 +81,7 @@ module MCP
           body = JSON.parse(response[2][0])
           assert_equal "2.0", body["jsonrpc"]
           assert_equal "123", body["id"]
-          assert_equal Configuration::DRAFT_PROTOCOL_VERSION, body["result"]["protocolVersion"]
+          assert_equal Configuration::LATEST_STABLE_PROTOCOL_VERSION, body["result"]["protocolVersion"]
         end
 
         test "handles GET request with valid session ID" do

--- a/test/mcp/server_test.rb
+++ b/test/mcp/server_test.rb
@@ -133,7 +133,7 @@ module MCP
         jsonrpc: "2.0",
         id: 1,
         result: {
-          protocolVersion: Configuration::DRAFT_PROTOCOL_VERSION,
+          protocolVersion: Configuration::LATEST_STABLE_PROTOCOL_VERSION,
           capabilities: {
             prompts: { listChanged: true },
             resources: { listChanged: true },
@@ -776,7 +776,7 @@ module MCP
       }
 
       response = @server.handle(request)
-      assert_equal Configuration::DRAFT_PROTOCOL_VERSION, response[:result][:protocolVersion]
+      assert_equal Configuration::LATEST_STABLE_PROTOCOL_VERSION, response[:result][:protocolVersion]
     end
 
     test "server response does not include title when not configured" do


### PR DESCRIPTION
## Motivation and Context

When starting an MCP server in Claude Code with `protocol_version` set to `DRAFT-2025-v3`, it fails with the following error:

```console
2025-12-04T02:58:01.548Z [DEBUG] MCP server "example": Connection failed after 2093ms: Server's protocol version is not supported: DRAFT-2025-v3
2025-12-04T02:58:01.548Z [ERROR] MCP server "example" Connection failed: Server's protocol version is not supported: DRAFT-2025-v3
```

This PR changes the default behavior so that if `protocol_version` is not specified, it uses the latest stable protocol version instead of the draft version.

This PR also updates the README to note that the latest stable protocol version includes new features from the draft version.

## How Has This Been Tested?

Existing tests have been updated to pass. I also verified its operation with Claude Code.

## Breaking Changes

None.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
