### PR TITLE
Add a missing assertion in `ConfigurationTest`

### DIFF
--- a/test/mcp/configuration_test.rb
+++ b/test/mcp/configuration_test.rb
@@ -12,8 +12,9 @@ module MCP
       exception = StandardError.new("test error")
       server_context = { test: "context" }
 
-      # Should not raise any errors
-      config.exception_reporter.call(exception, server_context)
+      assert_nothing_raised do
+        config.exception_reporter.call(exception, server_context)
+      end
     end
 
     test "allows setting a custom exception reporter" do


### PR DESCRIPTION
## Motivation and Context

This PR adds a missing assertion in `ConfigurationTest`.

## How Has This Been Tested?

The updated test passes with the new assertion.

## Breaking Changes

None.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
