### PR TITLE
Fix symlink path comparison in schema validation

### DIFF
--- a/lib/mcp/tool/input_schema.rb
+++ b/lib/mcp/tool/input_schema.rb
@@ -46,9 +46,10 @@ module MCP
       def validate_schema!
         check_for_refs!
         schema = to_h
+        gem_path = File.realpath(Gem.loaded_specs["json-schema"].full_gem_path)
         schema_reader = JSON::Schema::Reader.new(
           accept_uri: false,
-          accept_file: ->(path) { path.to_s.start_with?(Gem.loaded_specs["json-schema"].full_gem_path) },
+          accept_file: ->(path) { File.realpath(path.to_s).start_with?(gem_path) },
         )
         metaschema_path = Pathname.new(JSON::Validator.validator_for_name("draft4").metaschema)
         # Converts metaschema to a file URI for cross-platform compatibility

--- a/lib/mcp/tool/output_schema.rb
+++ b/lib/mcp/tool/output_schema.rb
@@ -51,9 +51,10 @@ module MCP
 
       def validate_schema!
         schema = to_h
+        gem_path = File.realpath(Gem.loaded_specs["json-schema"].full_gem_path)
         schema_reader = JSON::Schema::Reader.new(
           accept_uri: false,
-          accept_file: ->(path) { path.to_s.start_with?(Gem.loaded_specs["json-schema"].full_gem_path) },
+          accept_file: ->(path) { File.realpath(path.to_s).start_with?(gem_path) },
         )
         metaschema_path = Pathname.new(JSON::Validator.validator_for_name("draft4").metaschema)
         # Converts metaschema to a file URI for cross-platform compatibility


### PR DESCRIPTION
Fix symlink path comparison in schema validation to work in Nix environments.

## Motivation and Context
 The schema validation fails under Nix because it compares a symlinked gem path against the real file path without resolving symlinks. This causes the `accept_file` check to fail when the json-schema gem is installed via Nix.

```
Read of file at /nix/store/s2jg5wq3md8d2hipja0plcn06a1sc976-ruby3.4-json-schema-5.2.2/lib/ruby/gems/3.4.0/gems/json-schema-5.2.2/resources/draft-04.json refused
```

## How Has This Been Tested?
Tested by installing the gem in a local nix environment where the issue was originally occurring. After the fix, schema validation works correctly.

## Breaking Changes
None.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
The fix uses `File.realpath` to normalize both the gem path and the file path before comparison. This preserves the security check (only allowing reads from within the json-schema gem directory) while handling symlinked paths correctly.
