### PR TITLE
Show exception messages for tool call errors

### DIFF
--- a/lib/mcp/server.rb
+++ b/lib/mcp/server.rb
@@ -338,13 +338,11 @@ module MCP
         end
       end
 
-      begin
-        call_tool_with_args(tool, arguments)
-      rescue => e
-        report_exception(e, { request: request })
+      call_tool_with_args(tool, arguments)
+    rescue => e
+      report_exception(e, request: request)
 
-        error_tool_response("Internal error calling tool #{tool_name}: #{e.message}")
-      end
+      error_tool_response("Internal error calling tool #{tool_name}: #{e.message}")
     end
 
     def list_prompts(request)


### PR DESCRIPTION
## Motivation and Context

Claude Code sometimes only shows `Error: MCP error -32603: Internal error` when an unexpected exception occurs during a tool call.

This change broadens the exception handling scope so the server can surface the exception message more often, making failures easier to diagnose.

## How Has This Been Tested?

Existing tests pass.

## Breaking Changes

None.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
