### PR TITLE
Remove redundant `String#dup`

### DIFF
--- a/lib/mcp/string_utils.rb
+++ b/lib/mcp/string_utils.rb
@@ -15,7 +15,7 @@ module MCP
     end
 
     def underscore(camel_cased_word)
-      camel_cased_word.dup
+      camel_cased_word
         .gsub(/([A-Z]+)([A-Z][a-z])/, '\1_\2')
         .gsub(/([a-z\d])([A-Z])/, '\1_\2')
         .tr("-", "_")


### PR DESCRIPTION
## Motivation and Context

Since no destructive methods are being called, `dup` isn’t necessary.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
