### PR TITLE
Add support for the optional `description` parameter in `serverInfo`

### DIFF
--- a/lib/mcp/server.rb
+++ b/lib/mcp/server.rb
@@ -31,9 +31,10 @@ module MCP
 
     include Instrumentation
 
-    attr_accessor :name, :title, :version, :instructions, :tools, :prompts, :resources, :server_context, :configuration, :capabilities, :transport
+    attr_accessor :description, :name, :title, :version, :instructions, :tools, :prompts, :resources, :server_context, :configuration, :capabilities, :transport
 
     def initialize(
+      description: nil,
       name: "model_context_protocol",
       title: nil,
       version: DEFAULT_VERSION,
@@ -47,6 +48,7 @@ module MCP
       capabilities: nil,
       transport: nil
     )
+      @description = description
       @name = name
       @title = title
       @version = version
@@ -175,6 +177,13 @@ module MCP
 
     def validate!
       # NOTE: The draft protocol version is the next version after 2025-11-25.
+      if @configuration.protocol_version <= "2025-06-18"
+        if server_info.key?(:description)
+          message = "Error occurred in server_info. `description` is not supported in protocol version 2025-06-18 or earlier"
+          raise ArgumentError, message
+        end
+      end
+
       if @configuration.protocol_version <= "2025-03-26"
         if server_info.key?(:title)
           message = "Error occurred in server_info. `title` is not supported in protocol version 2025-03-26 or earlier"
@@ -255,6 +264,7 @@ module MCP
 
     def server_info
       @server_info ||= {
+        description:,
         name:,
         title:,
         version:,

--- a/test/mcp/server_test.rb
+++ b/test/mcp/server_test.rb
@@ -68,6 +68,7 @@ module MCP
       configuration.instrumentation_callback = instrumentation_helper.callback
 
       @server = Server.new(
+        description: "Test server",
         name: @server_name,
         title: "Example Server Display Name",
         version: "1.2.3",
@@ -140,6 +141,7 @@ module MCP
             tools: { listChanged: true },
           },
           serverInfo: {
+            description: "Test server",
             name: @server_name,
             title: "Example Server Display Name",
             version: "1.2.3",
@@ -813,6 +815,21 @@ module MCP
 
       response = server.handle(request)
       refute response[:result].key?(:instructions)
+    end
+
+    test "server uses description when configured with protocol version 2025-11-25" do
+      configuration = Configuration.new(protocol_version: "2025-11-25")
+      server = Server.new(description: "This is the MCP server used during tests.", name: "test_server", configuration: configuration)
+      assert_equal("This is the MCP server used during tests.", server.description)
+    end
+
+    test "raises error if description is used with protocol version 2025-06-18" do
+      configuration = Configuration.new(protocol_version: "2025-06-18")
+
+      exception = assert_raises(ArgumentError) do
+        Server.new(description: "This is the MCP server used during tests.", name: "test_server", configuration: configuration)
+      end
+      assert_equal("Error occurred in server_info. `description` is not supported in protocol version 2025-06-18 or earlier", exception.message)
     end
 
     test "server uses instructions when configured with protocol version 2025-03-26" do


### PR DESCRIPTION
## Motivation and Context

This PR adds support for the optional `description` parameter in `serverInfo`. This parameter has been supported since the 2025-11-25 MCP specification. https://modelcontextprotocol.io/specification/2025-11-25/schema#implementation

## How Has This Been Tested?

The tests have been updated and are now passing.

## Breaking Changes

None.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
