### PR TITLE
Add Ruby 4.0 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,11 @@ jobs:
     strategy:
       matrix:
         entry:
-          - { ruby: 3.2, allowed-failure: false }
-          - { ruby: 3.3, allowed-failure: false }
-          - { ruby: 3.4, allowed-failure: false }
-          - { ruby: head, allowed-failure: true }
+          - { ruby: '3.2', allowed-failure: false }
+          - { ruby: '3.3', allowed-failure: false }
+          - { ruby: '3.4', allowed-failure: false }
+          - { ruby: '4.0', allowed-failure: false }
+          - { ruby: 'head', allowed-failure: true }
     name: Test Ruby ${{ matrix.entry.ruby }}
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-          ruby-version: 3.4
+          ruby-version: 4.0
       - uses: rubygems/release-gem@v1
 
   publish_gh_pages:


### PR DESCRIPTION
## Motivation and Context

Ruby 4.0.0 has been released, so this PR adds Ruby 4.0 to CI.
https://www.ruby-lang.org/en/news/2025/12/25/ruby-4-0-0-released/

To prevent the CI label from showing "CI / Test Ruby 4" instead of "CI / Test Ruby 4.0", the matrix entries are changed from floats to strings.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
