### PR TITLE
[Doc] Remove redundant descriptions in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,9 +105,3 @@ This is the official Ruby SDK for the Model Context Protocol (MCP), implementing
 - **Rails controllers**: Use `server.handle_json(request.body.read)` for HTTP endpoints
 - **Command-line tools**: Use `StdioTransport.new(server).open` for CLI applications
 - **HTTP services**: Use `StreamableHttpTransport` for web-based servers
-
-### Component definition patterns
-
-1. **Class inheritance**: `class MyTool < MCP::Tool`
-2. **Define methods**: `MCP::Tool.define(name: "my_tool") { ... }`
-3. **Server registration**: `server.define_tool(name: "my_tool") { ... }`


### PR DESCRIPTION
## Motivation and Context

The "Component definition patterns" section has been removed because it overlaps with "Three Ways to Define Components" in AGENTS.md:
https://github.com/modelcontextprotocol/ruby-sdk/blob/d745ccde/AGENTS.md#key-patterns

This helps make the system prompt more concise.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
