### PR TITLE
Make tool names stricter

### DIFF
--- a/lib/mcp/tool.rb
+++ b/lib/mcp/tool.rb
@@ -4,6 +4,7 @@ module MCP
   class Tool
     class << self
       NOT_SET = Object.new
+      MAX_LENGTH_OF_NAME = 128
 
       attr_reader :title_value
       attr_reader :description_value
@@ -42,11 +43,13 @@ module MCP
           name_value
         else
           @name_value = value
+
+          validate!
         end
       end
 
       def name_value
-        @name_value || StringUtils.handle_from_class_name(name)
+        @name_value || (name.nil? ? nil : StringUtils.handle_from_class_name(name))
       end
 
       def input_schema_value
@@ -117,6 +120,22 @@ module MCP
           output_schema output_schema
           self.annotations(annotations) if annotations
           define_singleton_method(:call, &block) if block
+        end.tap(&:validate!)
+      end
+
+      # It complies with the following tool name specification:
+      # https://modelcontextprotocol.io/specification/latest/server/tools#tool-names
+      def validate!
+        return true unless tool_name
+
+        if tool_name.empty? || tool_name.length > MAX_LENGTH_OF_NAME
+          raise ArgumentError, "Tool names should be between 1 and 128 characters in length (inclusive)."
+        end
+
+        unless tool_name.match?(/\A[A-Za-z\d_\-\.]+\z/)
+          raise ArgumentError, <<~MESSAGE
+            Tool names only allowed characters: uppercase and lowercase ASCII letters (A-Z, a-z), digits (0-9), underscore (_), hyphen (-), and dot (.).
+          MESSAGE
         end
       end
     end

--- a/test/mcp/tool_test.rb
+++ b/test/mcp/tool_test.rb
@@ -434,5 +434,46 @@ module MCP
       expected_output = { type: "object", properties: { result: { type: "string" }, success: { type: "boolean" } }, required: ["result", "success"] }
       assert_equal expected_output, tool.output_schema.to_h
     end
+
+    test "accepts valid tool names" do
+      assert Tool.define(name: "getUser")
+      assert Tool.define(name: "DATA_EXPORT_v2")
+      assert Tool.define(name: "admin.tools.list")
+      assert Tool.define(name: "a" * 128)
+    end
+
+    test "raises an error when tool name is empty in class definition" do
+      error = assert_raises(ArgumentError) do
+        class EmptyTitleNameTool < Tool
+          tool_name ""
+        end
+      end
+      assert_equal("Tool names should be between 1 and 128 characters in length (inclusive).", error.message)
+    end
+
+    test "allows nil tool name in class definition" do
+      assert_nothing_raised do
+        class EmptyTitleNameTool < Tool
+          tool_name nil
+        end
+      end
+    end
+
+    test "raises an error when tool name is empty" do
+      error = assert_raises(ArgumentError) { Tool.define(name: "") }
+      assert_equal("Tool names should be between 1 and 128 characters in length (inclusive).", error.message)
+    end
+
+    test "raises an error when tool name exceeds 128 characters" do
+      error = assert_raises(ArgumentError) { Tool.define(name: "a" * 129) }
+      assert_equal("Tool names should be between 1 and 128 characters in length (inclusive).", error.message)
+    end
+
+    test "raises an error when tool name includes invalid characters (e.g., spaces)" do
+      error = assert_raises(ArgumentError) { Tool.define(name: "foo bar") }
+      assert_equal(<<~MESSAGE, error.message)
+        Tool names only allowed characters: uppercase and lowercase ASCII letters (A-Z, a-z), digits (0-9), underscore (_), hyphen (-), and dot (.).
+      MESSAGE
+    end
   end
 end


### PR DESCRIPTION
## Motivation and Context

Follow-up to https://github.com/modelcontextprotocol/ruby-sdk/pull/199#issuecomment-3659688807

Tool names are now validated to comply with the specification. https://modelcontextprotocol.io/specification/2025-11-25/server/tools#tool-names

Since the tool name is optional, `nil` value is treated as "not specified" and is ignored without validation.

## How Has This Been Tested?

It passes both the existing tests and the newly added tests.

## Breaking Changes

This introduces stricter naming validation that complies with the specification.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
