### PR TITLE
Add Accept header validation

### DIFF
--- a/lib/mcp/client/http.rb
+++ b/lib/mcp/client/http.rb
@@ -3,6 +3,8 @@
 module MCP
   class Client
     class HTTP
+      ACCEPT_HEADER = "application/json, text/event-stream"
+
       attr_reader :url
 
       def initialize(url:, headers: {})
@@ -14,46 +16,48 @@ module MCP
         method = request[:method] || request["method"]
         params = request[:params] || request["params"]
 
-        client.post("", request).body
+        response = client.post("", request)
+        validate_response_content_type!(response, method, params)
+        response.body
       rescue Faraday::BadRequestError => e
         raise RequestHandlerError.new(
           "The #{method} request is invalid",
-          { method:, params: },
+          { method: method, params: params },
           error_type: :bad_request,
           original_error: e,
         )
       rescue Faraday::UnauthorizedError => e
         raise RequestHandlerError.new(
           "You are unauthorized to make #{method} requests",
-          { method:, params: },
+          { method: method, params: params },
           error_type: :unauthorized,
           original_error: e,
         )
       rescue Faraday::ForbiddenError => e
         raise RequestHandlerError.new(
           "You are forbidden to make #{method} requests",
-          { method:, params: },
+          { method: method, params: params },
           error_type: :forbidden,
           original_error: e,
         )
       rescue Faraday::ResourceNotFound => e
         raise RequestHandlerError.new(
           "The #{method} request is not found",
-          { method:, params: },
+          { method: method, params: params },
           error_type: :not_found,
           original_error: e,
         )
       rescue Faraday::UnprocessableEntityError => e
         raise RequestHandlerError.new(
           "The #{method} request is unprocessable",
-          { method:, params: },
+          { method: method, params: params },
           error_type: :unprocessable_entity,
           original_error: e,
         )
       rescue Faraday::Error => e # Catch-all
         raise RequestHandlerError.new(
           "Internal error handling #{method} request",
-          { method:, params: },
+          { method: method, params: params },
           error_type: :internal_error,
           original_error: e,
         )
@@ -70,6 +74,7 @@ module MCP
           faraday.response(:json)
           faraday.response(:raise_error)
 
+          faraday.headers["Accept"] = ACCEPT_HEADER
           headers.each do |key, value|
             faraday.headers[key] = value
           end
@@ -82,6 +87,17 @@ module MCP
         raise LoadError, "The 'faraday' gem is required to use the MCP client HTTP transport. " \
           "Add it to your Gemfile: gem 'faraday', '>= 2.0'" \
           "See https://rubygems.org/gems/faraday for more details."
+      end
+
+      def validate_response_content_type!(response, method, params)
+        content_type = response.headers["Content-Type"]
+        return if content_type&.include?("application/json")
+
+        raise RequestHandlerError.new(
+          "Unsupported Content-Type: #{content_type.inspect}. This client only supports JSON responses.",
+          { method: method, params: params },
+          error_type: :unsupported_media_type,
+        )
       end
     end
   end

--- a/test/mcp/server/transports/streamable_http_notification_integration_test.rb
+++ b/test/mcp/server/transports/streamable_http_notification_integration_test.rb
@@ -232,11 +232,20 @@ module MCP
         private
 
         def create_rack_request(method, path, headers, body = nil)
+          default_accept = case method
+          when "POST"
+            { "HTTP_ACCEPT" => "application/json, text/event-stream" }
+          when "GET"
+            { "HTTP_ACCEPT" => "text/event-stream" }
+          else
+            {}
+          end
+
           env = {
             "REQUEST_METHOD" => method,
             "PATH_INFO" => path,
             "rack.input" => StringIO.new(body.to_s),
-          }.merge(headers)
+          }.merge(default_accept, headers)
 
           Rack::Request.new(env)
         end


### PR DESCRIPTION
## Motivation and Context

The [MCP 2025-06-18 specification](https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#sending-messages-to-the-server) requires clients to include specific `Accept` headers when communicating with servers via Streamable HTTP transport:

- POST requests MUST include both `application/json` and `text/event-stream`
- GET requests MUST include `text/event-stream`

This change brings the SDK into compliance with the specification by:
1. Server-side: Validating incoming Accept headers and returning 406 Not Acceptable when requirements aren't met
2. Client-side: Automatically including the required Accept header on all HTTP requests

## How Has This Been Tested?

- Added new unit tests.
- Ran this command to simulate the communication between MCP client and server.

```bash
bundle exec ruby -I lib -e '
require "mcp"
require "rack"

# Create server transport
transport = MCP::Server::Transports::StreamableHTTPTransport.new(MCP::Server.new(name: "test", version: "1.0"))

# Test 1: POST without Accept header should return 406
env = Rack::MockRequest.env_for("/mcp", method: "POST", input: "{}", "CONTENT_TYPE" => "application/json")
request = Rack::Request.new(env)
status, headers, body = transport.handle_request(request)
puts "Test 1 - POST without Accept header: #{status == 406 ? "PASS" : "FAIL"} (status: #{status})"

# Test 2: POST with only application/json should return 406
env = Rack::MockRequest.env_for("/mcp", method: "POST", input: "{}", "CONTENT_TYPE" => "application/json", "HTTP_ACCEPT" => "application/json")
request = Rack::Request.new(env)
status, headers, body = transport.handle_request(request)
puts "Test 2 - POST with only application/json: #{status == 406 ? "PASS" : "FAIL"} (status: #{status})"

# Test 3: POST with both required types should succeed (not 406)
env = Rack::MockRequest.env_for("/mcp", method: "POST", input: "{\"jsonrpc\":\"2.0\",\"method\":\"initialize\",\"id\":1}", "CONTENT_TYPE" => "application/json", "HTTP_ACCEPT" => "application/json, text/event-stream")
request = Rack::Request.new(env)
status, headers, body = transport.handle_request(request)
puts "Test 3 - POST with both required types: #{status != 406 ? "PASS" : "FAIL"} (status: #{status})"

# Test 4: GET without Accept header should return 406
env = Rack::MockRequest.env_for("/mcp", method: "GET")
request = Rack::Request.new(env)
status, headers, body = transport.handle_request(request)
puts "Test 4 - GET without Accept header: #{status == 406 ? "PASS" : "FAIL"} (status: #{status})"

# Test 5: Verify client includes Accept header constant
puts "Test 5 - Client Accept header constant: #{MCP::Client::HTTP::ACCEPT_HEADER == "application/json, text/event-stream" ? "PASS" : "FAIL"}"

puts "\nAll Accept header validation tests completed!"
'
```

```
Test 1 - POST without Accept header: PASS (status: 406)
Test 2 - POST with only application/json: PASS (status: 406)
Test 3 - POST with both required types: PASS (status: 200)
Test 4 - GET without Accept header: PASS (status: 406)
Test 5 - Client Accept header constant: PASS

All Accept header validation tests completed!
```

## Breaking Changes

Yes.

Servers will now reject requests without proper Accept headers with HTTP 406. Clients that don't send the required Accept header will receive an error response. However, compliant MCP clients should already be sending this header per the specification.

This change aligns with https://github.com/modelcontextprotocol/typescript-sdk/pull/266/changes#diff-fa2d8ab461bf11229eaa80d28cfa765b7244ab37a737a0b67f26aae8102175eeR121-R123.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed
