### PR TITLE
Fix ReDoS vulnerability in `StringUtils#underscore`

### DIFF
--- a/lib/mcp/string_utils.rb
+++ b/lib/mcp/string_utils.rb
@@ -16,8 +16,8 @@ module MCP
 
     def underscore(camel_cased_word)
       camel_cased_word
-        .gsub(/([A-Z]+)([A-Z][a-z])/, '\1_\2')
-        .gsub(/([a-z\d])([A-Z])/, '\1_\2')
+        .gsub(/(?<=[A-Z])(?=[A-Z][a-z])/, "_")
+        .gsub(/(?<=[a-z\d])(?=[A-Z])/, "_")
         .tr("-", "_")
         .downcase
     end

--- a/test/mcp/string_utils_test.rb
+++ b/test/mcp/string_utils_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "timeout"
 
 module MCP
   class StringUtilsTest < Minitest::Test
@@ -17,6 +18,19 @@ module MCP
     def test_handle_from_class_name_returns_the_class_name_without_the_module_for_a_class_with_multiple_parent_modules
       assert_equal("test", StringUtils.handle_from_class_name("Module::Submodule::Test"))
       assert_equal("test_class", StringUtils.handle_from_class_name("Module::Submodule::TestClass"))
+    end
+
+    def test_handle_from_class_name_does_not_cause_redos
+      # A long string of uppercase letters followed by a non-lowercase character
+      # would trigger catastrophic backtracking with the vulnerable regex patterns.
+      malicious_input = "A" * 50_000 + "!"
+
+      result = nil
+      Timeout.timeout(1) do
+        result = StringUtils.handle_from_class_name(malicious_input)
+      end
+
+      assert_equal("a" * 50_000 + "!", result)
     end
   end
 end


### PR DESCRIPTION
## Motivation and Context

Replace regex patterns with lookahead/lookbehind assertions to prevent catastrophic backtracking on Ruby 3.1 and earlier.

This issue only affects Ruby 3.1 and earlier. Since it does not occur on Ruby 3.2+, it is not an issue in the current stable release (0.4.0), which does not include #206.

## How Has This Been Tested?

Ensure the regex patterns complete within 1 second for a 50,000-character input that would otherwise trigger superlinear backtracking.

## Breaking Changes

None.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

