### PR TITLE
Add MCP Streamable HTTP specification support for the client

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem "rubocop-minitest", require: false
 gem "rubocop-rake", require: false
 gem "rubocop-shopify", ">= 2.18", require: false if RUBY_VERSION >= "3.1"
 
+gem "event_stream_parser", ">= 1.0"
 gem "puma", ">= 5.0.0"
 gem "rack-cors"
 gem "rackup", ">= 2.1.0"

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,6 @@ gem "rubocop-minitest", require: false
 gem "rubocop-rake", require: false
 gem "rubocop-shopify", ">= 2.18", require: false if RUBY_VERSION >= "3.1"
 
-gem "event_stream_parser", ">= 1.0"
 gem "puma", ">= 5.0.0"
 gem "rack-cors"
 gem "rackup", ">= 2.1.0"

--- a/examples/streamable_http_client.rb
+++ b/examples/streamable_http_client.rb
@@ -1,49 +1,29 @@
 # frozen_string_literal: true
 
+require "mcp"
+require "mcp/client"
+require "mcp/client/http"
+require "mcp/client/tool"
 require "net/http"
 require "uri"
 require "json"
 require "logger"
+require "event_stream_parser"
+
+SERVER_URL = "http://localhost:9393"
 
 # Logger for client operations
-logger = Logger.new($stdout)
-logger.formatter = proc do |severity, datetime, _progname, msg|
-  "[CLIENT] #{severity} #{datetime.strftime("%H:%M:%S.%L")} - #{msg}\n"
+def create_logger
+  logger = Logger.new($stdout)
+  logger.formatter = proc do |severity, datetime, _progname, msg|
+    "[CLIENT] #{severity} #{datetime.strftime("%H:%M:%S.%L")} - #{msg}\n"
+  end
+  logger
 end
 
-# Server configuration
-SERVER_URL = "http://localhost:9393/mcp"
-PROTOCOL_VERSION = "2024-11-05"
-
-# Helper method to make JSON-RPC requests
-def make_request(session_id, method, params = {}, id = nil)
-  uri = URI(SERVER_URL)
-  http = Net::HTTP.new(uri.host, uri.port)
-
-  request = Net::HTTP::Post.new(uri)
-  request["Content-Type"] = "application/json"
-  request["Mcp-Session-Id"] = session_id if session_id
-
-  body = {
-    jsonrpc: "2.0",
-    method: method,
-    params: params,
-    id: id || SecureRandom.uuid,
-  }
-
-  request.body = body.to_json
-  response = http.request(request)
-
-  {
-    status: response.code,
-    headers: response.to_hash,
-    body: JSON.parse(response.body),
-  }
-rescue => e
-  { error: e.message }
-end
-
-# Connect to SSE stream
+# Connect to SSE stream for real-time notifications
+# The SDK doesn't support HTTP GET for SSE streaming yet, so we use raw Net::HTTP
+# See: https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#listening-for-messages-from-the-server
 def connect_sse(session_id, logger)
   uri = URI(SERVER_URL)
 
@@ -59,17 +39,13 @@ def connect_sse(session_id, logger)
       if response.code == "200"
         logger.info("SSE stream connected successfully")
 
+        parser = EventStreamParser::Parser.new
         response.read_body do |chunk|
-          chunk.split("\n").each do |line|
-            if line.start_with?("data: ")
-              data = line[6..-1]
-              begin
-                logger.info("SSE data: #{data}")
-              rescue JSON::ParserError
-                logger.debug("Non-JSON SSE data: #{data}")
-              end
-            elsif line.start_with?(": ")
-              logger.debug("SSE keepalive received: #{line}")
+          parser.feed(chunk) do |type, data, _id|
+            if type.empty?
+              logger.info("SSE event: #{data}")
+            else
+              logger.info("SSE event (#{type}): #{data}")
             end
           end
         end
@@ -79,129 +55,128 @@ def connect_sse(session_id, logger)
     end
   end
 rescue Interrupt
-  logger.info("SSE connection interrupted by user")
+  logger.info("SSE connection interrupted")
 rescue => e
   logger.error("SSE connection error: #{e.message}")
 end
 
-# Main client flow
 def main
-  logger = Logger.new($stdout)
-  logger.formatter = proc do |severity, datetime, _progname, msg|
-    "[CLIENT] #{severity} #{datetime.strftime("%H:%M:%S.%L")} - #{msg}\n"
-  end
+  logger = create_logger
 
-  puts "=== MCP SSE Test Client ==="
+  puts <<~MESSAGE
+    MCP Streamable HTTP Client
+    Make sure the server is running (ruby examples/streamable_http_server.rb)
+    #{"=" * 60}
+  MESSAGE
 
-  # Step 1: Initialize session
-  logger.info("Initializing session...")
+  # Initialize SDK client
+  transport = MCP::Client::HTTP.new(url: SERVER_URL)
+  client = MCP::Client.new(transport: transport)
 
-  init_response = make_request(
-    nil,
-    "initialize",
-    {
-      protocolVersion: PROTOCOL_VERSION,
-      capabilities: {},
-      clientInfo: {
-        name: "sse-test-client",
-        version: "1.0",
-      },
-    },
-    "init-1",
-  )
-
-  if init_response[:error]
-    logger.error("Failed to initialize: #{init_response[:error]}")
-    exit(1)
-  end
-
-  session_id = init_response[:headers]["mcp-session-id"]&.first
-
-  if session_id.nil?
-    logger.error("No session ID received")
-    exit(1)
-  end
-
-  if init_response[:body].dig("result", "capabilities", "logging")
-    make_request(session_id, "logging/setLevel", { level: "info" })
-  end
-
-  logger.info("Session initialized: #{session_id}")
-  logger.info("Server info: #{init_response[:body]["result"]["serverInfo"]}")
-
-  # Step 2: Start SSE connection in a separate thread
-  sse_thread = Thread.new { connect_sse(session_id, logger) }
-
-  # Give SSE time to connect
-  sleep(1)
-
-  # Step 3: Interactive menu
-  loop do
-    puts <<~MESSAGE.chomp
-
-      === Available Actions ===
-      1. Send custom notification
-      2. Test echo
-      3. List tools
-      0. Exit
-
-      Choose an action:#{" "}
+  begin
+    # Initialize session using SDK
+    puts "=== Initializing session ==="
+    init_response = client.connect(
+      client_info: { name: "streamable-http-client", version: "1.0" },
+    )
+    puts <<~MESSAGE
+      ID: #{client.session_id}
+      Version: #{client.protocol_version}
+      Server: #{init_response.dig("result", "serverInfo")}
     MESSAGE
 
-    choice = gets.chomp
+    # Get available tools BEFORE establishing SSE connection
+    # (Once SSE is active, server sends responses via SSE stream, not POST response)
+    puts "=== Listing tools ==="
+    tools = client.tools
+    tools.each { |t| puts "  - #{t.name}: #{t.description}" }
 
-    case choice
-    when "1"
-      print("Enter notification message: ")
-      message = gets.chomp
-      print("Enter delay in seconds (0 for immediate): ")
-      delay = gets.chomp.to_f
+    echo_tool = tools.find { |t| t.name == "echo" }
+    notification_tool = tools.find { |t| t.name == "notification_tool" }
 
-      response = make_request(
-        session_id,
-        "tools/call",
-        {
-          name: "notification_tool",
-          arguments: {
-            message: message,
-            delay: delay,
-          },
-        },
-      )
-      if response[:body]["accepted"]
-        logger.info("Notification sent successfully")
+    # Start SSE connection in a separate thread (uses raw HTTP)
+    # Note: After this, server responses will be sent via SSE, not POST
+    sse_thread = Thread.new { connect_sse(client.session_id, logger) }
+
+    # Give SSE time to connect
+    sleep(1)
+
+    # Interactive menu
+    loop do
+      puts <<~MENU.chomp
+
+        === Available Actions ===
+        1. Send notification (triggers SSE event)
+        2. Echo message
+        3. List tools
+        0. Exit
+
+        Choose an action:#{" "}
+      MENU
+
+      choice = gets.chomp
+
+      case choice
+      when "1"
+        if notification_tool
+          print("Enter notification message: ")
+          message = gets.chomp
+          print("Enter delay in seconds (0 for immediate): ")
+          delay = gets.chomp.to_f
+
+          puts "=== Calling tool: notification_tool ==="
+          response = client.call_tool(
+            tool: notification_tool,
+            arguments: { message: message, delay: delay },
+          )
+          puts "Response: #{JSON.pretty_generate(response)}"
+        else
+          puts "notification_tool not available"
+        end
+      when "2"
+        if echo_tool
+          print("Enter message to echo: ")
+          message = gets.chomp
+
+          puts "=== Calling tool: echo ==="
+          response = client.call_tool(tool: echo_tool, arguments: { message: message })
+          puts "Response: #{JSON.pretty_generate(response)}"
+        else
+          puts "echo tool not available"
+        end
+      when "3"
+        puts "=== Listing tools ==="
+        puts "(Note: Response will appear in SSE stream when active)"
+        client.tools.each do |tool|
+          puts "  - #{tool.name}: #{tool.description}"
+        end
+      when "0"
+        logger.info("Exiting...")
+        break
       else
-        logger.error("Error: #{response[:body]["error"]}")
+        puts "Invalid choice"
       end
-    when "2"
-      print("Enter message to echo: ")
-      message = gets.chomp
-      make_request(session_id, "tools/call", { name: "echo", arguments: { message: message } })
-    when "3"
-      make_request(session_id, "tools/list")
-    when "0"
-      logger.info("Exiting...")
-      break
-    else
-      puts "Invalid choice"
     end
+  rescue MCP::Client::SessionExpiredError => e
+    logger.error("Session expired: #{e.message}")
+  rescue MCP::Client::RequestHandlerError => e
+    logger.error("Request error: #{e.message}")
+  rescue Interrupt
+    logger.info("Client interrupted")
+  rescue => e
+    logger.error("Error: #{e.message}")
+    logger.error(e.backtrace.first(5).join("\n"))
+  ensure
+    # Clean up SSE thread
+    sse_thread.kill if sse_thread&.alive?
+
+    # Close session using SDK
+    puts "=== Closing session ==="
+    client.close
+    puts "Session closed"
   end
-
-  # Clean up
-  sse_thread.kill if sse_thread.alive?
-
-  # Close session
-  logger.info("Closing session...")
-  make_request(session_id, "close")
-  logger.info("Session closed")
-rescue Interrupt
-  logger.info("Client interrupted by user")
-rescue => e
-  logger.error("Client error: #{e.message}")
-  logger.error(e.backtrace.join("\n"))
 end
 
-# Run the client
 if __FILE__ == $PROGRAM_NAME
   main
 end

--- a/examples/streamable_http_server.rb
+++ b/examples/streamable_http_server.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-$LOAD_PATH.unshift(File.expand_path("../lib", __dir__))
+# Usage: bundle exec ruby examples/streamable_http_server.rb
 require "mcp"
 require "rack/cors"
 require "rackup"
@@ -31,7 +31,7 @@ class NotificationTool < MCP::Tool
     def call(message:, delay: 0)
       sleep(delay) if delay > 0
 
-      logger&.info("Returning notification message: #{message}")
+      logger.info("Returning notification message: #{message}")
 
       MCP::Tool::Response.new([{
         type: "text",

--- a/lib/mcp/client.rb
+++ b/lib/mcp/client.rb
@@ -6,6 +6,11 @@ require_relative "client/tool"
 
 module MCP
   class Client
+    # https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#streamable-http
+    LATEST_PROTOCOL_VERSION = "2025-11-25"
+    SESSION_ID_HEADER = "Mcp-Session-Id"
+    PROTOCOL_VERSION_HEADER = "MCP-Protocol-Version"
+
     class ServerError < StandardError
       attr_reader :code, :data
 
@@ -27,21 +32,66 @@ module MCP
       end
     end
 
+    class SessionExpiredError < StandardError
+      attr_reader :request
+
+      def initialize(message, request)
+        super(message)
+        @request = request
+      end
+    end
+
     # Initializes a new MCP::Client instance.
     #
     # @param transport [Object] The transport object to use for communication with the server.
-    #   The transport should be a duck type that responds to `send_request`. See the README for more details.
+    #   The transport should be a duck type that responds to `post`. See the README for more details.
     #
     # @example
     #   transport = MCP::Client::HTTP.new(url: "http://localhost:3000")
     #   client = MCP::Client.new(transport: transport)
     def initialize(transport:)
       @transport = transport
+      @session_id = nil
+      @protocol_version = nil
     end
 
-    # The user may want to access additional transport-specific methods/attributes
-    # So keeping it public
-    attr_reader :transport
+    attr_reader :transport, :session_id, :protocol_version
+
+    def connected?
+      !@protocol_version.nil?
+    end
+
+    # Opens a connection to the MCP server by performing the initialization handshake.
+    #
+    # @param client_info [Hash] Information about the client (name, version)
+    # @param protocol_version [String] The protocol version to request
+    # @param capabilities [Hash] Client capabilities to advertise
+    # @return [Hash] The server's initialization response
+    #
+    # @example
+    #   client.connect(
+    #     client_info: { name: "my-client", version: "1.0.0" },
+    #   )
+    def connect(client_info:, protocol_version: LATEST_PROTOCOL_VERSION, capabilities: {})
+      request_body = {
+        jsonrpc: JsonRpcHandler::Version::V2_0,
+        id: request_id,
+        method: "initialize",
+        params: {
+          protocolVersion: protocol_version,
+          capabilities: capabilities,
+          clientInfo: client_info,
+        },
+      }
+
+      response = transport.post(body: request_body)
+
+      # Faraday normalizes headers to lowercase
+      @session_id = response.headers["mcp-session-id"]
+      @protocol_version = response.body.dig("result", "protocolVersion") || protocol_version
+
+      response.body
+    end
 
     # Returns the list of tools available from the server.
     # Each call will make a new request – the result is not cached.
@@ -163,6 +213,18 @@ module MCP
       response.dig("result", "completion") || { "values" => [], "hasMore" => false }
     end
 
+    # Closes the connection with the MCP server.
+    # For HTTP transport, this sends a DELETE request to terminate the session.
+    # Session state is cleared regardless of whether the DELETE succeeds.
+    # See: https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#session-termination
+    def close
+      return unless @session_id
+
+      transport.delete(headers: session_headers)
+      @session_id = nil
+      @protocol_version = nil
+    end
+
     private
 
     def request(method:, params: nil)
@@ -173,15 +235,27 @@ module MCP
       }
       request_body[:params] = params if params
 
-      response = transport.send_request(request: request_body)
+      response = transport.post(body: request_body, headers: session_headers)
+      body = response.body
 
       # Guard with `is_a?(Hash)` because custom transports may return non-Hash values.
-      if response.is_a?(Hash) && response.key?("error")
-        error = response["error"]
+      if body.is_a?(Hash) && body.key?("error")
+        error = body["error"]
         raise ServerError.new(error["message"], code: error["code"], data: error["data"])
       end
 
-      response
+      body
+    rescue SessionExpiredError
+      @session_id = nil
+      @protocol_version = nil
+      raise
+    end
+
+    def session_headers
+      headers = {}
+      headers[SESSION_ID_HEADER] = @session_id if @session_id
+      headers[PROTOCOL_VERSION_HEADER] = @protocol_version if @protocol_version
+      headers
     end
 
     def request_id

--- a/lib/mcp/client.rb
+++ b/lib/mcp/client.rb
@@ -6,7 +6,8 @@ require_relative "client/tool"
 
 module MCP
   class Client
-    # https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#streamable-http
+    # Protocol version and header constants for Streamable HTTP transport.
+    # See: https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#streamable-http
     LATEST_PROTOCOL_VERSION = "2025-11-25"
     SESSION_ID_HEADER = "Mcp-Session-Id"
     PROTOCOL_VERSION_HEADER = "MCP-Protocol-Version"
@@ -86,8 +87,8 @@ module MCP
 
       response = transport.post(body: request_body)
 
-      # Faraday normalizes headers to lowercase
-      @session_id = response.headers["mcp-session-id"]
+      # Faraday normalizes header names to lowercase
+      @session_id = response.headers[SESSION_ID_HEADER.downcase]
       @protocol_version = response.body.dig("result", "protocolVersion") || protocol_version
 
       response.body

--- a/lib/mcp/client/http.rb
+++ b/lib/mcp/client/http.rb
@@ -2,8 +2,13 @@
 
 module MCP
   class Client
+    # TODO: https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#listening-for-messages-from-the-server
+    # TODO: https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#resumability-and-redelivery
+
     class HTTP
       ACCEPT_HEADER = "application/json, text/event-stream"
+
+      Response = Struct.new(:body, :headers, keyword_init: true)
 
       attr_reader :url
 
@@ -12,13 +17,39 @@ module MCP
         @headers = headers
       end
 
+      # Sends a JSON-RPC request and returns only the response body.
+      #
+      # Use this method when:
+      # - You only need the response body (not headers)
+      # - You're using the transport directly without MCP::Client
+      # - You don't need session management
+      #
+      # @param request [Hash] The JSON-RPC request to send
+      # @return [Hash] The parsed response body
       def send_request(request:)
-        method = request[:method] || request["method"]
-        params = request[:params] || request["params"]
+        post(body: request).body
+      rescue SessionExpiredError => e
+        # Preserve original error type for backward compatibility
+        raise RequestHandlerError.new(
+          "The #{request[:method] || request["method"]} request is not found",
+          e.request,
+          error_type: :not_found,
+        )
+      end
 
-        response = client.post("", request)
-        validate_response_content_type!(response, method, params)
-        response.body
+      # Sends a POST request and returns both body and headers.
+      # Used internally by MCP::Client for session management.
+      # @param body [Hash] The JSON-RPC request body
+      # @param headers [Hash] Additional headers to include
+      # @return [Response] A struct containing body and headers
+      def post(body:, headers: {})
+        method = body[:method] || body["method"]
+        params = body[:params] || body["params"]
+
+        response = client(headers).post("", body)
+        parsed_body = parse_response_body(response, method, params)
+
+        Response.new(body: parsed_body, headers: response.headers.to_h)
       rescue Faraday::BadRequestError => e
         raise RequestHandlerError.new(
           "The #{method} request is invalid",
@@ -40,12 +71,13 @@ module MCP
           error_type: :forbidden,
           original_error: e,
         )
-      rescue Faraday::ResourceNotFound => e
-        raise RequestHandlerError.new(
-          "The #{method} request is not found",
+      rescue Faraday::ResourceNotFound
+        # The server MAY terminate the session at any time,
+        # after which it MUST respond to requests containing that session ID with HTTP 404 Not Found.
+        # See: https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#session-management
+        raise SessionExpiredError.new(
+          "Session expired or not found (HTTP 404)",
           { method: method, params: params },
-          error_type: :not_found,
-          original_error: e,
         )
       rescue Faraday::UnprocessableEntityError => e
         raise RequestHandlerError.new(
@@ -63,21 +95,27 @@ module MCP
         )
       end
 
+      def delete(headers: {})
+        client(headers).delete("")
+        nil
+      rescue Faraday::Error
+        nil
+      end
+
       private
 
       attr_reader :headers
 
-      def client
+      def client(request_headers = {})
         require_faraday!
-        @client ||= Faraday.new(url) do |faraday|
+        Faraday.new(url) do |faraday|
           faraday.request(:json)
           faraday.response(:json)
           faraday.response(:raise_error)
 
           faraday.headers["Accept"] = ACCEPT_HEADER
-          headers.each do |key, value|
-            faraday.headers[key] = value
-          end
+          headers.each { |key, value| faraday.headers[key] = value }
+          request_headers.each { |key, value| faraday.headers[key] = value }
         end
       end
 
@@ -89,14 +127,42 @@ module MCP
           "See https://rubygems.org/gems/faraday for more details."
       end
 
-      def validate_response_content_type!(response, method, params)
+      def parse_response_body(response, method, params)
         content_type = response.headers["Content-Type"]
-        return if content_type&.include?("application/json")
+
+        if content_type&.include?("text/event-stream")
+          parse_sse_response(response.body, method, params)
+        elsif content_type&.include?("application/json")
+          response.body
+        else
+          raise RequestHandlerError.new(
+            "Unsupported Content-Type: #{content_type.inspect}. Expected application/json or text/event-stream.",
+            { method: method, params: params },
+            error_type: :unsupported_media_type,
+          )
+        end
+      end
+
+      def parse_sse_response(body, method, params)
+        json_rpc_response = nil
+        parser = EventStreamParser::Parser.new
+        parser.feed(body.to_s) do |_type, data, _id|
+          next if data.empty?
+
+          begin
+            parsed = JSON.parse(data)
+            json_rpc_response = parsed if parsed.is_a?(Hash) && (parsed.key?("result") || parsed.key?("error"))
+          rescue JSON::ParserError
+            next
+          end
+        end
+
+        return json_rpc_response if json_rpc_response
 
         raise RequestHandlerError.new(
-          "Unsupported Content-Type: #{content_type.inspect}. This client only supports JSON responses.",
+          "No valid JSON-RPC response found in SSE stream",
           { method: method, params: params },
-          error_type: :unsupported_media_type,
+          error_type: :parse_error,
         )
       end
     end

--- a/lib/mcp/client/http.rb
+++ b/lib/mcp/client/http.rb
@@ -2,8 +2,10 @@
 
 module MCP
   class Client
-    # TODO: https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#listening-for-messages-from-the-server
-    # TODO: https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#resumability-and-redelivery
+    # TODO: HTTP GET for SSE streaming is not yet implemented.
+    #   See: https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#listening-for-messages-from-the-server
+    # TODO: Resumability and redelivery with Last-Event-ID is not yet implemented.
+    #   See: https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#resumability-and-redelivery
 
     class HTTP
       ACCEPT_HEADER = "application/json, text/event-stream"

--- a/lib/mcp/client/http.rb
+++ b/lib/mcp/client/http.rb
@@ -134,6 +134,9 @@ module MCP
           parse_sse_response(response.body, method, params)
         elsif content_type&.include?("application/json")
           response.body
+        elsif response.status == 202
+          # Server accepted the request and will deliver the response via SSE stream
+          { "accepted" => true }
         else
           raise RequestHandlerError.new(
             "Unsupported Content-Type: #{content_type.inspect}. Expected application/json or text/event-stream.",

--- a/lib/mcp/server/transports/streamable_http_transport.rb
+++ b/lib/mcp/server/transports/streamable_http_transport.rb
@@ -6,7 +6,8 @@ require_relative "../../transport"
 module MCP
   class Server
     module Transports
-      # TODO: https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#resumability-and-redelivery
+      # TODO: Resumability and redelivery with Last-Event-ID is not yet implemented.
+      #   See: https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#resumability-and-redelivery
 
       class StreamableHTTPTransport < Transport
         def initialize(server, stateless: false, session_idle_timeout: nil)

--- a/lib/mcp/server/transports/streamable_http_transport.rb
+++ b/lib/mcp/server/transports/streamable_http_transport.rb
@@ -6,6 +6,8 @@ require_relative "../../transport"
 module MCP
   class Server
     module Transports
+      # TODO: https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#resumability-and-redelivery
+
       class StreamableHTTPTransport < Transport
         def initialize(server, stateless: false, session_idle_timeout: nil)
           super(server)
@@ -34,6 +36,8 @@ module MCP
         SESSION_REAP_INTERVAL = 60
 
         def handle_request(request)
+          # TODO: https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#security-warning
+
           case request.env["REQUEST_METHOD"]
           when "POST"
             handle_post(request)

--- a/mcp.gemspec
+++ b/mcp.gemspec
@@ -30,5 +30,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency("event_stream_parser", ">= 1.0")
   spec.add_dependency("json-schema", ">= 4.1")
 end

--- a/test/mcp/client/http_test.rb
+++ b/test/mcp/client/http_test.rb
@@ -1,39 +1,54 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "event_stream_parser"
 require "faraday"
 require "webmock/minitest"
 require "mcp/client/http"
-require "mcp/client/tool"
 require "mcp/client"
 
 module MCP
   class Client
     class HTTPTest < Minitest::Test
       def test_raises_load_error_when_faraday_not_available
-        client = HTTP.new(url: url)
+        transport = HTTP.new(url: url)
 
-        # simulate Faraday not being available
         HTTP.any_instance.stubs(:require).with("faraday").raises(LoadError, "cannot load such file -- faraday")
 
         error = assert_raises(LoadError) do
-          # This should immediately try to instantiate the client and fail
-          client.send_request(request: {})
+          transport.post(body: {})
         end
 
         assert_includes(error.message, "The 'faraday' gem is required to use the MCP client HTTP transport")
         assert_includes(error.message, "Add it to your Gemfile: gem 'faraday', '>= 2.0'")
       end
 
-      def test_headers_are_added_to_the_request
-        headers = { "Authorization" => "Bearer token" }
-        client = HTTP.new(url: url, headers: headers)
+      def test_post_with_default_headers
+        body = { jsonrpc: "2.0", id: "test_id", method: "tools/list" }
 
-        request = {
-          jsonrpc: "2.0",
-          id: "test_id",
-          method: "tools/list",
-        }
+        stub_request(:post, url)
+          .with(
+            headers: {
+              "Content-Type" => "application/json",
+              "Accept" => "application/json, text/event-stream",
+            },
+            body: body.to_json,
+          )
+          .to_return(
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: { result: { tools: [] } }.to_json,
+          )
+
+        response = transport.post(body: body)
+
+        assert_instance_of(HTTP::Response, response)
+        assert_equal({ "result" => { "tools" => [] } }, response.body)
+      end
+
+      def test_post_with_custom_transport_headers
+        custom_transport = HTTP.new(url: url, headers: { "Authorization" => "Bearer token" })
+        body = { jsonrpc: "2.0", id: "test_id", method: "tools/list" }
 
         stub_request(:post, url)
           .with(
@@ -42,7 +57,6 @@ module MCP
               "Content-Type" => "application/json",
               "Accept" => "application/json, text/event-stream",
             },
-            body: request.to_json,
           )
           .to_return(
             status: 200,
@@ -50,22 +64,17 @@ module MCP
             body: { result: { tools: [] } }.to_json,
           )
 
-        # The test passes if the request is made with the correct headers
-        # If headers are wrong, the stub_request won't match and will raise
-        client.send_request(request: request)
+        custom_transport.post(body: body)
       end
 
-      def test_accept_header_is_included_in_requests
-        request = {
-          jsonrpc: "2.0",
-          id: "test_id",
-          method: "tools/list",
-        }
+      def test_post_with_request_specific_headers
+        body = { jsonrpc: "2.0", id: "test_id", method: "tools/list" }
 
         stub_request(:post, url)
           .with(
             headers: {
-              "Accept" => "application/json, text/event-stream",
+              "MCP-Session-Id" => "session-123",
+              "MCP-Protocol-Version" => "2024-11-05",
             },
           )
           .to_return(
@@ -74,199 +83,212 @@ module MCP
             body: { result: { tools: [] } }.to_json,
           )
 
-        client.send_request(request: request)
+        transport.post(
+          body: body,
+          headers: {
+            "MCP-Session-Id" => "session-123",
+            "MCP-Protocol-Version" => "2024-11-05",
+          },
+        )
       end
 
-      def test_custom_accept_header_overrides_default
-        custom_accept = "application/json"
-        custom_client = HTTP.new(url: url, headers: { "Accept" => custom_accept })
-
-        request = {
-          jsonrpc: "2.0",
-          id: "test_id",
-          method: "tools/list",
-        }
+      def test_post_returns_response_with_headers
+        body = { jsonrpc: "2.0", id: "test_id", method: "initialize" }
 
         stub_request(:post, url)
-          .with(
+          .to_return(
+            status: 200,
             headers: {
-              "Accept" => custom_accept,
+              "Content-Type" => "application/json",
+              "MCP-Session-Id" => "session-abc",
             },
-          )
-          .to_return(
-            status: 200,
-            headers: { "Content-Type" => "application/json" },
-            body: { result: { tools: [] } }.to_json,
+            body: { result: {} }.to_json,
           )
 
-        custom_client.send_request(request: request)
+        response = transport.post(body: body)
+
+        # Faraday normalizes header keys to lowercase
+        assert_equal("session-abc", response.headers["mcp-session-id"])
       end
 
-      def test_send_request_returns_faraday_response
-        request = {
-          jsonrpc: "2.0",
-          id: "test_id",
-          method: "tools/list",
-        }
-
-        stub_request(:post, url)
-          .with(body: request.to_json)
-          .to_return(
-            status: 200,
-            headers: { "Content-Type" => "application/json" },
-            body: { result: { tools: [] } }.to_json,
-          )
-
-        response = client.send_request(request: request)
-        assert_instance_of(Hash, response)
-        assert_equal({ "result" => { "tools" => [] } }, response)
-      end
-
-      def test_send_request_raises_bad_request_error
-        request = {
-          jsonrpc: "2.0",
-          id: "test_id",
-          method: "tools/list",
-        }
-
-        stub_request(:post, url)
-          .with(body: request.to_json)
-          .to_return(status: 400)
+      def test_post_raises_bad_request_error
+        stub_request(:post, url).to_return(status: 400)
 
         error = assert_raises(RequestHandlerError) do
-          client.send_request(request: request)
+          transport.post(body: {})
         end
 
-        assert_equal("The tools/list request is invalid", error.message)
+        assert_includes(error.message, "request is invalid")
         assert_equal(:bad_request, error.error_type)
-        assert_equal({ method: "tools/list", params: nil }, error.request)
       end
 
-      def test_send_request_raises_unauthorized_error
-        request = {
-          jsonrpc: "2.0",
-          id: "test_id",
-          method: "tools/list",
-        }
-
-        stub_request(:post, url)
-          .with(body: request.to_json)
-          .to_return(status: 401)
+      def test_post_raises_unauthorized_error
+        stub_request(:post, url).to_return(status: 401)
 
         error = assert_raises(RequestHandlerError) do
-          client.send_request(request: request)
+          transport.post(body: {})
         end
 
-        assert_equal("You are unauthorized to make tools/list requests", error.message)
+        assert_includes(error.message, "unauthorized")
         assert_equal(:unauthorized, error.error_type)
-        assert_equal({ method: "tools/list", params: nil }, error.request)
       end
 
-      def test_send_request_raises_forbidden_error
-        request = {
-          jsonrpc: "2.0",
-          id: "test_id",
-          method: "tools/list",
-        }
-
-        stub_request(:post, url)
-          .with(body: request.to_json)
-          .to_return(status: 403)
+      def test_post_raises_forbidden_error
+        stub_request(:post, url).to_return(status: 403)
 
         error = assert_raises(RequestHandlerError) do
-          client.send_request(request: request)
+          transport.post(body: {})
         end
 
-        assert_equal("You are forbidden to make tools/list requests", error.message)
+        assert_includes(error.message, "forbidden")
         assert_equal(:forbidden, error.error_type)
-        assert_equal({ method: "tools/list", params: nil }, error.request)
       end
 
-      def test_send_request_raises_not_found_error
-        request = {
-          jsonrpc: "2.0",
-          id: "test_id",
-          method: "tools/list",
-        }
+      def test_post_raises_session_expired_error_on_404
+        stub_request(:post, url).to_return(status: 404)
 
-        stub_request(:post, url)
-          .with(body: request.to_json)
-          .to_return(status: 404)
-
-        error = assert_raises(RequestHandlerError) do
-          client.send_request(request: request)
+        error = assert_raises(SessionExpiredError) do
+          transport.post(body: {})
         end
 
-        assert_equal("The tools/list request is not found", error.message)
+        assert_includes(error.message, "Session expired")
+      end
+
+      def test_send_request_raises_request_handler_error_on_404_for_backward_compatibility
+        stub_request(:post, url).to_return(status: 404)
+
+        error = assert_raises(RequestHandlerError) do
+          transport.send_request(request: { method: "tools/list" })
+        end
+
+        assert_includes(error.message, "not found")
         assert_equal(:not_found, error.error_type)
-        assert_equal({ method: "tools/list", params: nil }, error.request)
       end
 
-      def test_send_request_raises_unprocessable_entity_error
-        request = {
-          jsonrpc: "2.0",
-          id: "test_id",
-          method: "tools/list",
-        }
-
-        stub_request(:post, url)
-          .with(body: request.to_json)
-          .to_return(status: 422)
+      def test_post_raises_unprocessable_entity_error
+        stub_request(:post, url).to_return(status: 422)
 
         error = assert_raises(RequestHandlerError) do
-          client.send_request(request: request)
+          transport.post(body: {})
         end
 
-        assert_equal("The tools/list request is unprocessable", error.message)
+        assert_includes(error.message, "unprocessable")
         assert_equal(:unprocessable_entity, error.error_type)
-        assert_equal({ method: "tools/list", params: nil }, error.request)
       end
 
-      def test_send_request_raises_internal_error
-        request = {
-          jsonrpc: "2.0",
-          id: "test_id",
-          method: "tools/list",
-        }
-
-        stub_request(:post, url)
-          .with(body: request.to_json)
-          .to_return(status: 500)
+      def test_post_raises_internal_error_on_500
+        stub_request(:post, url).to_return(status: 500)
 
         error = assert_raises(RequestHandlerError) do
-          client.send_request(request: request)
+          transport.post(body: {})
         end
 
-        assert_equal("Internal error handling tools/list request", error.message)
+        assert_includes(error.message, "Internal error")
         assert_equal(:internal_error, error.error_type)
-        assert_equal({ method: "tools/list", params: nil }, error.request)
       end
 
-      def test_send_request_raises_error_for_non_json_response
-        request = {
-          jsonrpc: "2.0",
-          id: "test_id",
-          method: "tools/list",
-        }
+      def test_post_raises_error_for_unsupported_content_type
+        stub_request(:post, url)
+          .to_return(
+            status: 200,
+            headers: { "Content-Type" => "text/html" },
+            body: "<html></html>",
+          )
+
+        error = assert_raises(RequestHandlerError) do
+          transport.post(body: {})
+        end
+
+        assert_includes(error.message, "Unsupported Content-Type")
+        assert_equal(:unsupported_media_type, error.error_type)
+      end
+
+      def test_post_parses_sse_response
+        sse_body = <<~SSE
+          : comment
+          data: {"jsonrpc":"2.0","method":"notifications/progress","params":{}}
+
+          data: {"jsonrpc":"2.0","id":"test_id","result":{"tools":[{"name":"echo"}]}}
+
+        SSE
 
         stub_request(:post, url)
-          .with(body: request.to_json)
           .to_return(
             status: 200,
             headers: { "Content-Type" => "text/event-stream" },
-            body: "data: {}\n\n",
+            body: sse_body,
+          )
+
+        response = transport.post(body: {})
+
+        assert_equal({ "tools" => [{ "name" => "echo" }] }, response.body["result"])
+      end
+
+      def test_post_parses_sse_error_response
+        sse_body = <<~SSE
+          data: {"jsonrpc":"2.0","id":"test_id","error":{"code":-32600,"message":"Invalid request"}}
+
+        SSE
+
+        stub_request(:post, url)
+          .to_return(
+            status: 200,
+            headers: { "Content-Type" => "text/event-stream" },
+            body: sse_body,
+          )
+
+        response = transport.post(body: {})
+
+        assert_equal(-32600, response.body.dig("error", "code"))
+        assert_equal("Invalid request", response.body.dig("error", "message"))
+      end
+
+      def test_post_raises_error_for_sse_without_response
+        sse_body = <<~SSE
+          : just a comment
+          data: {"jsonrpc":"2.0","method":"notifications/progress","params":{}}
+
+        SSE
+
+        stub_request(:post, url)
+          .to_return(
+            status: 200,
+            headers: { "Content-Type" => "text/event-stream" },
+            body: sse_body,
           )
 
         error = assert_raises(RequestHandlerError) do
-          client.send_request(request: request)
+          transport.post(body: {})
         end
 
-        assert_equal(
-          'Unsupported Content-Type: "text/event-stream". This client only supports JSON responses.',
-          error.message,
+        assert_includes(error.message, "No valid JSON-RPC response found in SSE stream")
+        assert_equal(:parse_error, error.error_type)
+      end
+
+      def test_delete_sends_request_with_headers
+        stub_request(:delete, url)
+          .with(
+            headers: {
+              "MCP-Session-Id" => "session-123",
+              "MCP-Protocol-Version" => "2024-11-05",
+            },
+          )
+          .to_return(status: 200)
+
+        transport.delete(
+          headers: {
+            "MCP-Session-Id" => "session-123",
+            "MCP-Protocol-Version" => "2024-11-05",
+          },
         )
-        assert_equal(:unsupported_media_type, error.error_type)
-        assert_equal({ method: "tools/list", params: nil }, error.request)
+      end
+
+      def test_delete_handles_errors_gracefully
+        stub_request(:delete, url).to_return(status: 500)
+
+        # Should not raise, just returns nil
+        result = transport.delete(headers: {})
+        assert_nil(result)
       end
 
       private
@@ -279,8 +301,8 @@ module MCP
         "http://example.com"
       end
 
-      def client
-        @client ||= HTTP.new(url: url)
+      def transport
+        @transport ||= HTTP.new(url: url)
       end
     end
   end

--- a/test/mcp/client/http_test.rb
+++ b/test/mcp/client/http_test.rb
@@ -265,6 +265,15 @@ module MCP
         assert_equal(:parse_error, error.error_type)
       end
 
+      def test_post_returns_accepted_for_202_with_no_content_type
+        stub_request(:post, url)
+          .to_return(status: 202, body: "")
+
+        response = transport.post(body: {})
+
+        assert_equal({ "accepted" => true }, response.body)
+      end
+
       def test_delete_sends_request_with_headers
         stub_request(:delete, url)
           .with(

--- a/test/mcp/client_test.rb
+++ b/test/mcp/client_test.rb
@@ -5,9 +5,14 @@ require "securerandom"
 
 module MCP
   class ClientTest < Minitest::Test
+    # Helper to create a mock response struct like HTTP::Response
+    def mock_response(body:, headers: {})
+      Struct.new(:body, :headers, keyword_init: true).new(body: body, headers: headers)
+    end
+
     def test_tools_sends_request_to_transport_and_returns_tools_array
       transport = mock
-      mock_response = {
+      response_body = {
         "result" => {
           "tools" => [
             { "name" => "tool1", "description" => "tool1", "inputSchema" => {} },
@@ -17,9 +22,9 @@ module MCP
       }
 
       # Only checking for the essential parts of the request
-      transport.expects(:send_request).with do |args|
-        args.dig(:request, :method) == "tools/list" && args.dig(:request, :jsonrpc) == "2.0"
-      end.returns(mock_response).once
+      transport.expects(:post).with do |args|
+        args.dig(:body, :method) == "tools/list" && args.dig(:body, :jsonrpc) == "2.0"
+      end.returns(mock_response(body: response_body)).once
 
       client = Client.new(transport: transport)
       tools = client.tools
@@ -31,12 +36,12 @@ module MCP
 
     def test_tools_returns_empty_array_when_no_tools
       transport = mock
-      mock_response = { "result" => { "tools" => [] } }
+      response_body = { "result" => { "tools" => [] } }
 
       # Only checking for the essential parts of the request
-      transport.expects(:send_request).with do |args|
-        args.dig(:request, :method) == "tools/list" && args.dig(:request, :jsonrpc) == "2.0"
-      end.returns(mock_response).once
+      transport.expects(:post).with do |args|
+        args.dig(:body, :method) == "tools/list" && args.dig(:body, :jsonrpc) == "2.0"
+      end.returns(mock_response(body: response_body)).once
 
       client = Client.new(transport: transport)
       tools = client.tools
@@ -48,17 +53,17 @@ module MCP
       transport = mock
       tool = MCP::Client::Tool.new(name: "tool1", description: "tool1", input_schema: {})
       arguments = { foo: "bar" }
-      mock_response = {
+      response_body = {
         "result" => { "content" => [{ "type": "text", "text": "Hello, world!" }] },
       }
 
       # Only checking for the essential parts of the request
-      transport.expects(:send_request).with do |args|
-        args.dig(:request, :method) == "tools/call" &&
-          args.dig(:request, :jsonrpc) == "2.0" &&
-          args.dig(:request, :params, :name) == "tool1" &&
-          args.dig(:request, :params, :arguments) == arguments
-      end.returns(mock_response).once
+      transport.expects(:post).with do |args|
+        args.dig(:body, :method) == "tools/call" &&
+          args.dig(:body, :jsonrpc) == "2.0" &&
+          args.dig(:body, :params, :name) == "tool1" &&
+          args.dig(:body, :params, :arguments) == arguments
+      end.returns(mock_response(body: response_body)).once
 
       client = Client.new(transport: transport)
       result = client.call_tool(tool: tool, arguments: arguments)
@@ -70,14 +75,14 @@ module MCP
     def test_call_tool_by_name
       transport = mock
       arguments = { foo: "bar" }
-      mock_response = {
+      response_body = {
         "result" => { "content" => [{ "type": "text", "text": "Hello, world!" }] },
       }
 
-      transport.expects(:send_request).with do |args|
-        args.dig(:request, :params, :name) == "tool1" &&
-          args.dig(:request, :params, :arguments) == arguments
-      end.returns(mock_response).once
+      transport.expects(:post).with do |args|
+        args.dig(:body, :params, :name) == "tool1" &&
+          args.dig(:body, :params, :arguments) == arguments
+      end.returns(mock_response(body: response_body)).once
 
       client = Client.new(transport: transport)
       result = client.call_tool(name: "tool1", arguments: arguments)
@@ -95,7 +100,7 @@ module MCP
 
     def test_resources_sends_request_to_transport_and_returns_resources_array
       transport = mock
-      mock_response = {
+      response_body = {
         "result" => {
           "resources" => [
             { "name" => "resource1", "uri" => "file:///path/to/resource1", "description" => "First resource" },
@@ -105,9 +110,9 @@ module MCP
       }
 
       # Only checking for the essential parts of the request
-      transport.expects(:send_request).with do |args|
-        args.dig(:request, :method) == "resources/list" && args.dig(:request, :jsonrpc) == "2.0"
-      end.returns(mock_response).once
+      transport.expects(:post).with do |args|
+        args.dig(:body, :method) == "resources/list" && args.dig(:body, :jsonrpc) == "2.0"
+      end.returns(mock_response(body: response_body)).once
 
       client = Client.new(transport: transport)
       resources = client.resources
@@ -121,9 +126,9 @@ module MCP
 
     def test_resources_returns_empty_array_when_no_resources
       transport = mock
-      mock_response = { "result" => { "resources" => [] } }
+      response_body = { "result" => { "resources" => [] } }
 
-      transport.expects(:send_request).returns(mock_response).once
+      transport.expects(:post).returns(mock_response(body: response_body)).once
 
       client = Client.new(transport: transport)
       resources = client.resources
@@ -134,7 +139,7 @@ module MCP
     def test_read_resource_sends_request_to_transport_and_returns_contents
       transport = mock
       uri = "file:///path/to/resource.txt"
-      mock_response = {
+      response_body = {
         "result" => {
           "contents" => [
             { "uri" => uri, "mimeType" => "text/plain", "text" => "Hello, world!" },
@@ -143,11 +148,11 @@ module MCP
       }
 
       # Only checking for the essential parts of the request
-      transport.expects(:send_request).with do |args|
-        args.dig(:request, :method) == "resources/read" &&
-          args.dig(:request, :jsonrpc) == "2.0" &&
-          args.dig(:request, :params, :uri) == uri
-      end.returns(mock_response).once
+      transport.expects(:post).with do |args|
+        args.dig(:body, :method) == "resources/read" &&
+          args.dig(:body, :jsonrpc) == "2.0" &&
+          args.dig(:body, :params, :uri) == uri
+      end.returns(mock_response(body: response_body)).once
 
       client = Client.new(transport: transport)
       contents = client.read_resource(uri: uri)
@@ -161,9 +166,9 @@ module MCP
     def test_read_resource_returns_empty_array_when_no_contents
       transport = mock
       uri = "file:///path/to/nonexistent.txt"
-      mock_response = { "result" => {} }
+      response_body = { "result" => {} }
 
-      transport.expects(:send_request).returns(mock_response).once
+      transport.expects(:post).returns(mock_response(body: response_body)).once
 
       client = Client.new(transport: transport)
       contents = client.read_resource(uri: uri)
@@ -173,7 +178,7 @@ module MCP
 
     def test_resource_templates_sends_request_to_transport_and_returns_resource_templates_array
       transport = mock
-      mock_response = {
+      response_body = {
         "result" => {
           "resourceTemplates" => [
             { "name" => "template1", "uriTemplate" => "file:///path/{filename}", "description" => "First template" },
@@ -182,9 +187,9 @@ module MCP
         },
       }
 
-      transport.expects(:send_request).with do |args|
-        args.dig(:request, :method) == "resources/templates/list" && args.dig(:request, :jsonrpc) == "2.0"
-      end.returns(mock_response).once
+      transport.expects(:post).with do |args|
+        args.dig(:body, :method) == "resources/templates/list" && args.dig(:body, :jsonrpc) == "2.0"
+      end.returns(mock_response(body: response_body)).once
 
       client = Client.new(transport: transport)
       resource_templates = client.resource_templates
@@ -198,9 +203,9 @@ module MCP
 
     def test_resource_templates_returns_empty_array_when_no_resource_templates
       transport = mock
-      mock_response = { "result" => { "resourceTemplates" => [] } }
+      response_body = { "result" => { "resourceTemplates" => [] } }
 
-      transport.expects(:send_request).returns(mock_response).once
+      transport.expects(:post).returns(mock_response(body: response_body)).once
 
       client = Client.new(transport: transport)
       resource_templates = client.resource_templates
@@ -210,7 +215,7 @@ module MCP
 
     def test_prompts_sends_request_to_transport_and_returns_prompts_array
       transport = mock
-      mock_response = {
+      response_body = {
         "result" => {
           "prompts" => [
             {
@@ -240,9 +245,9 @@ module MCP
       }
 
       # Only checking for the essential parts of the request
-      transport.expects(:send_request).with do |args|
-        args.dig(:request, :method) == "prompts/list" && args.dig(:request, :jsonrpc) == "2.0"
-      end.returns(mock_response).once
+      transport.expects(:post).with do |args|
+        args.dig(:body, :method) == "prompts/list" && args.dig(:body, :jsonrpc) == "2.0"
+      end.returns(mock_response(body: response_body)).once
 
       client = Client.new(transport: transport)
       prompts = client.prompts
@@ -263,9 +268,9 @@ module MCP
 
     def test_prompts_returns_empty_array_when_no_prompts
       transport = mock
-      mock_response = { "result" => { "prompts" => [] } }
+      response_body = { "result" => { "prompts" => [] } }
 
-      transport.expects(:send_request).returns(mock_response).once
+      transport.expects(:post).returns(mock_response(body: response_body)).once
 
       client = Client.new(transport: transport)
       prompts = client.prompts
@@ -276,7 +281,7 @@ module MCP
     def test_get_prompt_sends_request_to_transport_and_returns_contents
       transport = mock
       name = "first_prompt"
-      mock_response = {
+      response_body = {
         "result" => {
           "description" => "First prompt",
           "messages" => [
@@ -292,11 +297,11 @@ module MCP
       }
 
       # Only checking for the essential parts of the request
-      transport.expects(:send_request).with do |args|
-        args.dig(:request, :method) == "prompts/get" &&
-          args.dig(:request, :jsonrpc) == "2.0" &&
-          args.dig(:request, :params, :name) == name
-      end.returns(mock_response).once
+      transport.expects(:post).with do |args|
+        args.dig(:body, :method) == "prompts/get" &&
+          args.dig(:body, :jsonrpc) == "2.0" &&
+          args.dig(:body, :params, :name) == name
+      end.returns(mock_response(body: response_body)).once
 
       client = Client.new(transport: transport)
       contents = client.get_prompt(name: name)
@@ -309,9 +314,9 @@ module MCP
     def test_get_prompt_returns_empty_hash_when_no_contents
       transport = mock
       name = "nonexistent_prompt"
-      mock_response = { "result" => {} }
+      response_body = { "result" => {} }
 
-      transport.expects(:send_request).returns(mock_response).once
+      transport.expects(:post).returns(mock_response(body: response_body)).once
 
       client = Client.new(transport: transport)
       contents = client.get_prompt(name: name)
@@ -322,9 +327,9 @@ module MCP
     def test_get_prompt_returns_empty_hash
       transport = mock
       name = "nonexistent_prompt"
-      mock_response = {}
+      response_body = {}
 
-      transport.expects(:send_request).returns(mock_response).once
+      transport.expects(:post).returns(mock_response(body: response_body)).once
 
       client = Client.new(transport: transport)
       contents = client.get_prompt(name: name)
@@ -337,16 +342,16 @@ module MCP
       tool = MCP::Client::Tool.new(name: "tool1", description: "tool1", input_schema: {})
       arguments = { foo: "bar" }
       progress_token = "my-progress-token"
-      mock_response = {
+      response_body = {
         "result" => { "content" => [{ "type": "text", "text": "Hello, world!" }] },
       }
 
-      transport.expects(:send_request).with do |args|
-        args.dig(:request, :method) == "tools/call" &&
-          args.dig(:request, :params, :_meta, :progressToken) == progress_token &&
-          args.dig(:request, :params, :name) == "tool1" &&
-          args.dig(:request, :params, :arguments) == arguments
-      end.returns(mock_response).once
+      transport.expects(:post).with do |args|
+        args.dig(:body, :method) == "tools/call" &&
+          args.dig(:body, :params, :_meta, :progressToken) == progress_token &&
+          args.dig(:body, :params, :name) == "tool1" &&
+          args.dig(:body, :params, :arguments) == arguments
+      end.returns(mock_response(body: response_body)).once
 
       client = Client.new(transport: transport)
       client.call_tool(tool: tool, arguments: arguments, progress_token: progress_token)
@@ -356,15 +361,15 @@ module MCP
       transport = mock
       tool = MCP::Client::Tool.new(name: "tool1", description: "tool1", input_schema: {})
       arguments = { foo: "bar" }
-      mock_response = {
+      response_body = {
         "result" => { "content" => [{ "type": "text", "text": "Hello, world!" }] },
       }
 
-      transport.expects(:send_request).with do |args|
-        args.dig(:request, :method) == "tools/call" &&
-          args.dig(:request, :params, :name) == "tool1" &&
-          args.dig(:request, :params).key?(:_meta) == false
-      end.returns(mock_response).once
+      transport.expects(:post).with do |args|
+        args.dig(:body, :method) == "tools/call" &&
+          args.dig(:body, :params, :name) == "tool1" &&
+          args.dig(:body, :params).key?(:_meta) == false
+      end.returns(mock_response(body: response_body)).once
 
       client = Client.new(transport: transport)
       client.call_tool(tool: tool, arguments: arguments)
@@ -372,9 +377,9 @@ module MCP
 
     def test_tools_raises_server_error_on_error_response
       transport = mock
-      mock_response = { "error" => { "code" => -32_601, "message" => "Method not found" } }
+      response_body = { "error" => { "code" => -32_601, "message" => "Method not found" } }
 
-      transport.expects(:send_request).returns(mock_response).once
+      transport.expects(:post).returns(mock_response(body: response_body)).once
 
       client = Client.new(transport: transport)
       error = assert_raises(Client::ServerError) { client.tools }
@@ -384,9 +389,9 @@ module MCP
 
     def test_resources_raises_server_error_on_error_response
       transport = mock
-      mock_response = { "error" => { "code" => -32_602, "message" => "Invalid params" } }
+      response_body = { "error" => { "code" => -32_602, "message" => "Invalid params" } }
 
-      transport.expects(:send_request).returns(mock_response).once
+      transport.expects(:post).returns(mock_response(body: response_body)).once
 
       client = Client.new(transport: transport)
       error = assert_raises(Client::ServerError) { client.resources }
@@ -395,9 +400,9 @@ module MCP
 
     def test_read_resource_raises_server_error_on_error_response
       transport = mock
-      mock_response = { "error" => { "code" => -32_602, "message" => "Resource not found" } }
+      response_body = { "error" => { "code" => -32_602, "message" => "Resource not found" } }
 
-      transport.expects(:send_request).returns(mock_response).once
+      transport.expects(:post).returns(mock_response(body: response_body)).once
 
       client = Client.new(transport: transport)
       assert_raises(Client::ServerError) { client.read_resource(uri: "file:///missing") }
@@ -405,9 +410,9 @@ module MCP
 
     def test_get_prompt_raises_server_error_on_error_response
       transport = mock
-      mock_response = { "error" => { "code" => -32_602, "message" => "Prompt not found" } }
+      response_body = { "error" => { "code" => -32_602, "message" => "Prompt not found" } }
 
-      transport.expects(:send_request).returns(mock_response).once
+      transport.expects(:post).returns(mock_response(body: response_body)).once
 
       client = Client.new(transport: transport)
       assert_raises(Client::ServerError) { client.get_prompt(name: "missing") }
@@ -415,9 +420,9 @@ module MCP
 
     def test_prompts_raises_server_error_on_error_response
       transport = mock
-      mock_response = { "error" => { "code" => -32_601, "message" => "Method not found" } }
+      response_body = { "error" => { "code" => -32_601, "message" => "Method not found" } }
 
-      transport.expects(:send_request).returns(mock_response).once
+      transport.expects(:post).returns(mock_response(body: response_body)).once
 
       client = Client.new(transport: transport)
       assert_raises(Client::ServerError) { client.prompts }
@@ -425,9 +430,9 @@ module MCP
 
     def test_resource_templates_raises_server_error_on_error_response
       transport = mock
-      mock_response = { "error" => { "code" => -32_601, "message" => "Method not found" } }
+      response_body = { "error" => { "code" => -32_601, "message" => "Method not found" } }
 
-      transport.expects(:send_request).returns(mock_response).once
+      transport.expects(:post).returns(mock_response(body: response_body)).once
 
       client = Client.new(transport: transport)
       assert_raises(Client::ServerError) { client.resource_templates }
@@ -435,9 +440,9 @@ module MCP
 
     def test_call_tool_raises_server_error_on_error_response
       transport = mock
-      mock_response = { "error" => { "code" => -32_602, "message" => "Tool not found" } }
+      response_body = { "error" => { "code" => -32_602, "message" => "Tool not found" } }
 
-      transport.expects(:send_request).returns(mock_response).once
+      transport.expects(:post).returns(mock_response(body: response_body)).once
 
       client = Client.new(transport: transport)
       error = assert_raises(Client::ServerError) { client.call_tool(name: "missing") }
@@ -446,11 +451,11 @@ module MCP
 
     def test_server_error_includes_data_field
       transport = mock
-      mock_response = {
+      response_body = {
         "error" => { "code" => -32_603, "message" => "Internal error", "data" => "extra details" },
       }
 
-      transport.expects(:send_request).returns(mock_response).once
+      transport.expects(:post).returns(mock_response(body: response_body)).once
 
       client = Client.new(transport: transport)
       error = assert_raises(Client::ServerError) { client.tools }
@@ -459,18 +464,20 @@ module MCP
 
     def test_complete_raises_server_error_on_error_response
       transport = mock
-      mock_response = { "error" => { "code" => -32_602, "message" => "Invalid params" } }
+      response_body = { "error" => { "code" => -32_602, "message" => "Invalid params" } }
 
-      transport.expects(:send_request).returns(mock_response).once
+      transport.expects(:post).returns(mock_response(body: response_body)).once
 
       client = Client.new(transport: transport)
-      error = assert_raises(Client::ServerError) { client.complete(ref: { type: "ref/prompt", name: "missing" }, argument: { name: "arg", value: "" }) }
+      error = assert_raises(Client::ServerError) do
+        client.complete(ref: { type: "ref/prompt", name: "missing" }, argument: { name: "arg", value: "" })
+      end
       assert_equal(-32_602, error.code)
     end
 
     def test_complete_sends_request_and_returns_completion_result
       transport = mock
-      mock_response = {
+      response_body = {
         "result" => {
           "completion" => {
             "values" => ["python", "pytorch"],
@@ -479,13 +486,13 @@ module MCP
         },
       }
 
-      transport.expects(:send_request).with do |args|
-        args.dig(:request, :method) == "completion/complete" &&
-          args.dig(:request, :jsonrpc) == "2.0" &&
-          args.dig(:request, :params, :ref) == { type: "ref/prompt", name: "code_review" } &&
-          args.dig(:request, :params, :argument) == { name: "language", value: "py" } &&
-          !args.dig(:request, :params).key?(:context)
-      end.returns(mock_response).once
+      transport.expects(:post).with do |args|
+        args.dig(:body, :method) == "completion/complete" &&
+          args.dig(:body, :jsonrpc) == "2.0" &&
+          args.dig(:body, :params, :ref) == { type: "ref/prompt", name: "code_review" } &&
+          args.dig(:body, :params, :argument) == { name: "language", value: "py" } &&
+          !args.dig(:body, :params).key?(:context)
+      end.returns(mock_response(body: response_body)).once
 
       client = Client.new(transport: transport)
       result = client.complete(
@@ -499,7 +506,7 @@ module MCP
 
     def test_complete_includes_context_when_provided
       transport = mock
-      mock_response = {
+      response_body = {
         "result" => {
           "completion" => {
             "values" => ["flask"],
@@ -508,9 +515,9 @@ module MCP
         },
       }
 
-      transport.expects(:send_request).with do |args|
-        args.dig(:request, :params, :context) == { arguments: { language: "python" } }
-      end.returns(mock_response).once
+      transport.expects(:post).with do |args|
+        args.dig(:body, :params, :context) == { arguments: { language: "python" } }
+      end.returns(mock_response(body: response_body)).once
 
       client = Client.new(transport: transport)
       result = client.complete(
@@ -524,9 +531,9 @@ module MCP
 
     def test_complete_returns_default_when_result_is_missing
       transport = mock
-      mock_response = { "result" => {} }
+      response_body = { "result" => {} }
 
-      transport.expects(:send_request).returns(mock_response).once
+      transport.expects(:post).returns(mock_response(body: response_body)).once
 
       client = Client.new(transport: transport)
       result = client.complete(
@@ -536,6 +543,211 @@ module MCP
 
       assert_equal([], result["values"])
       refute(result["hasMore"])
+    end
+
+    def test_connected_returns_false_before_connect
+      transport = mock
+      client = Client.new(transport: transport)
+
+      refute(client.connected?)
+      assert_nil(client.session_id)
+      assert_nil(client.protocol_version)
+    end
+
+    def test_connect_extracts_session_id_and_protocol_version
+      transport = mock
+      response_body = {
+        "result" => {
+          "protocolVersion" => "2024-11-05",
+          "serverInfo" => { "name" => "test-server", "version" => "1.0" },
+          "capabilities" => {},
+        },
+      }
+
+      transport.expects(:post).with do |args|
+        args.dig(:body, :method) == "initialize" &&
+          args.dig(:body, :params, :clientInfo, :name) == "test-client"
+      end.returns(mock_response(body: response_body, headers: { "mcp-session-id" => "session-123" })).once
+
+      client = Client.new(transport: transport)
+      result = client.connect(client_info: { name: "test-client", version: "1.0" })
+
+      assert(client.connected?)
+      assert_equal("session-123", client.session_id)
+      assert_equal("2024-11-05", client.protocol_version)
+      assert_equal("test-server", result.dig("result", "serverInfo", "name"))
+    end
+
+    def test_connect_uses_server_protocol_version
+      transport = mock
+      response_body = {
+        "result" => {
+          "protocolVersion" => "2025-03-26",
+          "serverInfo" => {},
+          "capabilities" => {},
+        },
+      }
+
+      transport.expects(:post).returns(mock_response(body: response_body, headers: {})).once
+
+      client = Client.new(transport: transport)
+      client.connect(
+        client_info: { name: "test-client", version: "1.0" },
+        protocol_version: "2024-11-05",
+      )
+
+      assert_equal("2025-03-26", client.protocol_version)
+    end
+
+    def test_request_includes_session_headers_after_initialization
+      transport = mock
+
+      init_response = mock_response(
+        body: { "result" => { "protocolVersion" => "2024-11-05" } },
+        headers: { "mcp-session-id" => "session-abc" },
+      )
+      transport.expects(:post).returns(init_response).once
+
+      client = Client.new(transport: transport)
+      client.connect(client_info: { name: "test", version: "1.0" })
+
+      tools_response = mock_response(body: { "result" => { "tools" => [] } })
+      transport.expects(:post).with do |args|
+        args[:headers][Client::SESSION_ID_HEADER] == "session-abc" &&
+          args[:headers][Client::PROTOCOL_VERSION_HEADER] == "2024-11-05"
+      end.returns(tools_response).once
+
+      client.tools
+    end
+
+    def test_session_expired_clears_session_state
+      transport = mock
+
+      init_response = mock_response(
+        body: { "result" => { "protocolVersion" => "2024-11-05" } },
+        headers: { "mcp-session-id" => "session-xyz" },
+      )
+      transport.expects(:post).returns(init_response).once
+
+      client = Client.new(transport: transport)
+      client.connect(client_info: { name: "test", version: "1.0" })
+
+      assert_equal("session-xyz", client.session_id)
+
+      transport.expects(:post).raises(Client::SessionExpiredError.new("Session expired", {}))
+
+      assert_raises(Client::SessionExpiredError) do
+        client.tools
+      end
+
+      assert_nil(client.session_id)
+      assert_nil(client.protocol_version)
+    end
+
+    def test_close_sends_delete_request_with_session_headers
+      transport = mock
+
+      init_response = mock_response(
+        body: { "result" => { "protocolVersion" => "2024-11-05" } },
+        headers: { "mcp-session-id" => "session-to-close" },
+      )
+      transport.expects(:post).returns(init_response).once
+
+      client = Client.new(transport: transport)
+      client.connect(client_info: { name: "test", version: "1.0" })
+
+      transport.expects(:delete).with do |args|
+        args[:headers][Client::SESSION_ID_HEADER] == "session-to-close" &&
+          args[:headers][Client::PROTOCOL_VERSION_HEADER] == "2024-11-05"
+      end.once
+
+      client.close
+
+      assert_nil(client.session_id)
+      assert_nil(client.protocol_version)
+    end
+
+    def test_close_does_nothing_without_session
+      transport = mock
+      client = Client.new(transport: transport)
+
+      # delete should not be called
+      transport.expects(:delete).never
+
+      client.close
+
+      assert_nil(client.session_id)
+    end
+
+    def test_session_id_not_overwritten_by_subsequent_responses
+      transport = mock
+
+      init_response = mock_response(
+        body: { "result" => { "protocolVersion" => "2024-11-05" } },
+        headers: { "mcp-session-id" => "original-session" },
+      )
+      transport.expects(:post).returns(init_response).once
+
+      client = Client.new(transport: transport)
+      client.connect(client_info: { name: "test", version: "1.0" })
+
+      assert_equal("original-session", client.session_id)
+
+      # Subsequent response has different session ID (shouldn't happen per spec)
+      tools_response = mock_response(
+        body: { "result" => { "tools" => [] } },
+        headers: { "mcp-session-id" => "different-session" },
+      )
+      transport.expects(:post).returns(tools_response).once
+
+      client.tools
+
+      # Original session ID should be preserved
+      assert_equal("original-session", client.session_id)
+    end
+
+    def test_connect_works_without_session_id_for_stateless_servers
+      transport = mock
+      response_body = {
+        "result" => {
+          "protocolVersion" => "2024-11-05",
+          "serverInfo" => { "name" => "stateless-server", "version" => "1.0" },
+          "capabilities" => {},
+        },
+      }
+
+      # Stateless server doesn't return session ID
+      transport.expects(:post).returns(mock_response(body: response_body, headers: {})).once
+
+      client = Client.new(transport: transport)
+      client.connect(client_info: { name: "test", version: "1.0" })
+
+      # Client is still connected even without session ID
+      assert(client.connected?)
+      assert_nil(client.session_id)
+      assert_equal("2024-11-05", client.protocol_version)
+    end
+
+    def test_request_works_without_session_id_for_stateless_servers
+      transport = mock
+
+      init_response = mock_response(
+        body: { "result" => { "protocolVersion" => "2024-11-05" } },
+        headers: {},
+      )
+      transport.expects(:post).returns(init_response).once
+
+      client = Client.new(transport: transport)
+      client.connect(client_info: { name: "test", version: "1.0" })
+
+      tools_response = mock_response(body: { "result" => { "tools" => [] } })
+      transport.expects(:post).with do |args|
+        # Session ID header should not be present for stateless servers
+        !args[:headers].key?(Client::SESSION_ID_HEADER) &&
+          args[:headers][Client::PROTOCOL_VERSION_HEADER] == "2024-11-05"
+      end.returns(tools_response).once
+
+      client.tools
     end
   end
 end


### PR DESCRIPTION
## Motivation and Context

Implements the [MCP Streamable HTTP specification](https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#streamable-http) for the Ruby SDK client.

Rebased from #210 (original by @keisku) with merge conflict resolution, bug fixes, and review feedback addressed.

**Already supported:**
- POST with JSON body
- `Accept: application/json, text/event-stream` header
- Parse `application/json` response

**This PR adds:**
- Parse `text/event-stream` (SSE) response via `event_stream_parser` gem
- Session management (`MCP-Session-Id` header)
- Handle 404 as session expiration
- Handle 202 Accepted when server delivers response via SSE stream
- DELETE for session termination
- Protocol version header (`MCP-Protocol-Version`)
- Client conformance test runner (`conformance/client.rb`)

## How Has This Been Tested?

**Unit tests** — 59 tests pass (40 client + 19 HTTP transport):
```
ruby -I lib -I test test/mcp/client_test.rb      # 40 runs, 125 assertions, 0 failures
ruby -I lib -I test test/mcp/client/http_test.rb  # 19 runs, 48 assertions, 0 failures
```

**Conformance tests** — core client scenarios pass:
```
npx @modelcontextprotocol/conformance client --suite core --command "ruby conformance/client.rb"

✓ initialize: 1 passed, 0 failed
✓ tools_call: 1 passed, 0 failed
```

**E2E** — manual testing with `examples/streamable_http_server.rb` and `examples/streamable_http_client.rb`.

## Breaking Changes

None. The public `send_request(request:)` method signature is preserved for backward compatibility.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## API Design

- `MCP::Client::HTTP#send_request(request:)` — Returns body only (backward compatible)
- `MCP::Client::HTTP#post(body:, headers:)` — Returns `Response` struct with body + headers (for session management)
- `MCP::Client::HTTP#delete(headers:)` — For session termination
- `MCP::Client#connect(client_info:, protocol_version:, capabilities:)` — Initialization handshake
- `MCP::Client#close` — Session termination

## Pending TODOs

- [Client GET for SSE stream](https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#streamable-http)
- [Resumability with `Last-Event-ID` header](https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#resumability-and-redelivery)
- [Origin header validation (server-side)](https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#security-warning)