### PR TITLE
Add Tool Arguments to Instrumentation Data

### DIFF
--- a/lib/mcp/server.rb
+++ b/lib/mcp/server.rb
@@ -322,7 +322,7 @@ module MCP
       end
 
       arguments = request[:arguments] || {}
-      add_instrumentation_data(tool_name: tool_name)
+      add_instrumentation_data(tool_name: tool_name, tool_arguments: arguments)
 
       if tool.input_schema&.missing_required_arguments?(arguments)
         add_instrumentation_data(error: :missing_required_arguments)

--- a/test/mcp/server_test.rb
+++ b/test/mcp/server_test.rb
@@ -264,7 +264,7 @@ module MCP
 
       response = @server.handle(request)
       assert_equal tool_response.to_h, response[:result]
-      assert_instrumentation_data({ method: "tools/call", tool_name: tool_name })
+      assert_instrumentation_data({ method: "tools/call", tool_name: tool_name, tool_arguments: tool_args })
     end
 
     test "#handle tools/call returns error response with isError true if required tool arguments are missing" do
@@ -320,7 +320,7 @@ module MCP
       raw_response = @server.handle_json(request)
       response = JSON.parse(raw_response, symbolize_names: true) if raw_response
       assert_equal tool_response.to_h, response[:result] if response
-      assert_instrumentation_data({ method: "tools/call", tool_name: tool_name })
+      assert_instrumentation_data({ method: "tools/call", tool_name: tool_name, tool_arguments: { arg: "value" } })
     end
 
     test "#handle_json tools/call executes tool and returns result, when the tool is typed with Sorbet" do
@@ -389,7 +389,7 @@ module MCP
       assert response[:result][:isError]
       assert_equal "text", response[:result][:content][0][:type]
       assert_match(/Internal error calling tool tool_that_raises: /, response[:result][:content][0][:text])
-      assert_instrumentation_data({ method: "tools/call", tool_name: "tool_that_raises" })
+      assert_instrumentation_data({ method: "tools/call", tool_name: "tool_that_raises", tool_arguments: { message: "test" } })
     end
 
     test "registers tools with the same class name in different namespaces" do
@@ -446,7 +446,7 @@ module MCP
       assert response[:result][:isError]
       assert_equal "text", response[:result][:content][0][:type]
       assert_match(/Internal error calling tool tool_that_raises: /, response[:result][:content][0][:text])
-      assert_instrumentation_data({ method: "tools/call", tool_name: "tool_that_raises" })
+      assert_instrumentation_data({ method: "tools/call", tool_name: "tool_that_raises", tool_arguments: { message: "test" } })
     end
 
     test "#handle tools/call returns error response with isError true if input_schema raises an error during validation" do


### PR DESCRIPTION
Include the tool arguments in instrumentation callback data when tools/call is invoked. This allows consumers to track which arguments were passed to each tool call for analytics and debugging purposes.

<!-- Provide a brief summary of your changes -->

## Motivation and Context
Include tool arguments in instrumentation callback data when tools/call is invoked, allowing consumers to track which arguments were passed to each tool call, useful for debugging and analysis.

## How Has This Been Tested?
Yes, tested with the Chattermill MCP (proprietary).

## Breaking Changes
No breaking changes.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed