### PR TITLE
[Doc] Acknowledge Shopify in the initial release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,4 +122,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.0] - 2025-05-30
 
-Initial release
+Initial release in collaboration with Shopify


### PR DESCRIPTION
## Motivation and Context

The repository's "About" section currently states, "The official Ruby SDK for the Model Context Protocol. Maintained in collaboration with Shopify." However, now that MCP governance has been established, maintenance is handled by the MCP steering group.

Given this, it seems more accurate to remove the maintenance wording from the "About" section. That said, I think it would be good to preserve acknowledgment of Shopify, which originally developed and released the Ruby SDK.

There may be a more appropriate place for this, but at the very least, it could be recorded in the changelog as part of the project's history.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
