### PR TITLE
Fix `Resource::Embedded` not setting `@resource` in `initialize`

### DIFF
--- a/lib/mcp/resource/embedded.rb
+++ b/lib/mcp/resource/embedded.rb
@@ -6,6 +6,7 @@ module MCP
       attr_reader :resource, :annotations
 
       def initialize(resource:, annotations: nil)
+        @resource = resource
         @annotations = annotations
       end
 

--- a/test/mcp/resource/embedded_test.rb
+++ b/test/mcp/resource/embedded_test.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module MCP
+  class Resource
+    class EmbeddedTest < ActiveSupport::TestCase
+      test "initializes with resource" do
+        resource = Resource.new(
+          uri: "file:///test.txt",
+          name: "test_resource",
+          description: "a test resource",
+        )
+        embedded = Resource::Embedded.new(resource: resource)
+
+        assert_equal resource, embedded.resource
+      end
+
+      test "initializes with resource and annotations" do
+        resource = Resource.new(
+          uri: "file:///test.txt",
+          name: "test_resource",
+          description: "a test resource",
+        )
+        annotations = { audience: ["user"], priority: 1.0 }
+        embedded = Resource::Embedded.new(resource: resource, annotations: annotations)
+
+        assert_equal resource, embedded.resource
+        assert_equal annotations, embedded.annotations
+      end
+
+      test "initializes with annotations as nil when not provided" do
+        resource = Resource.new(
+          uri: "file:///test.txt",
+          name: "test_resource",
+          description: "a test resource",
+        )
+        embedded = Resource::Embedded.new(resource: resource)
+
+        assert_nil embedded.annotations
+      end
+
+      test "#to_h returns hash with resource data when annotations is nil" do
+        resource = Resource.new(
+          uri: "file:///test.txt",
+          name: "test_resource",
+          description: "a test resource",
+        )
+        embedded = Resource::Embedded.new(resource: resource)
+
+        expected = {
+          resource: {
+            uri: "file:///test.txt",
+            name: "test_resource",
+            description: "a test resource",
+          },
+        }
+
+        assert_equal expected, embedded.to_h
+      end
+
+      test "#to_h returns hash with resource and annotations when both are present" do
+        resource = Resource.new(
+          uri: "file:///test.txt",
+          name: "test_resource",
+          description: "a test resource",
+        )
+        annotations = { audience: ["user"], priority: 1.0 }
+        embedded = Resource::Embedded.new(resource: resource, annotations: annotations)
+
+        expected = {
+          resource: {
+            uri: "file:///test.txt",
+            name: "test_resource",
+            description: "a test resource",
+          },
+          annotations: { audience: ["user"], priority: 1.0 },
+        }
+
+        assert_equal expected, embedded.to_h
+      end
+
+      test "#to_h handles resource with all optional fields" do
+        resource = Resource.new(
+          uri: "file:///test.txt",
+          name: "test_resource",
+          title: "Test Resource",
+          description: "a test resource",
+          mime_type: "text/plain",
+        )
+        embedded = Resource::Embedded.new(resource: resource)
+
+        expected = {
+          resource: {
+            uri: "file:///test.txt",
+            name: "test_resource",
+            title: "Test Resource",
+            description: "a test resource",
+            mimeType: "text/plain",
+          },
+        }
+
+        assert_equal expected, embedded.to_h
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Motivation and Context

The `initialize` method was missing the assignment of `@resource`, causing the resource method to always return `nil` and `to_h` to return an incorrect hash with an empty resource value.

## How Has This Been Tested?

Added comprehensive tests to verify the fix and prevent regression.

## Breaking Changes

None.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

