### PR TITLE
Add client info to instrumentation callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,7 @@ The instrumentation callback receives a hash with the following possible keys:
 - `resource_uri`: (String, optional) The URI of the resource called
 - `error`: (String, optional) Error code if a lookup failed
 - `duration`: (Float) Duration of the call in seconds
+- `client`: (Hash, optional) Client information with `name` and `version` keys, from the initialize request
 
 **Type:**
 

--- a/test/mcp/server_test.rb
+++ b/test/mcp/server_test.rb
@@ -159,6 +159,53 @@ module MCP
       assert_instrumentation_data({ method: "initialize" })
     end
 
+    test "#handle initialize request with clientInfo includes client in instrumentation data" do
+      client_info = { name: "test_client", version: "1.0.0" }
+      request = {
+        jsonrpc: "2.0",
+        method: "initialize",
+        id: 1,
+        params: {
+          clientInfo: client_info,
+        },
+      }
+
+      @server.handle(request)
+      assert_instrumentation_data({ method: "initialize", client: client_info })
+    end
+
+    test "instrumentation data includes client info for subsequent requests after initialize" do
+      client_info = { name: "test_client", version: "1.0.0" }
+      initialize_request = {
+        jsonrpc: "2.0",
+        method: "initialize",
+        id: 1,
+        params: {
+          clientInfo: client_info,
+        },
+      }
+      @server.handle(initialize_request)
+
+      ping_request = {
+        jsonrpc: "2.0",
+        method: "ping",
+        id: 2,
+      }
+      @server.handle(ping_request)
+      assert_instrumentation_data({ method: "ping", client: client_info })
+    end
+
+    test "instrumentation data does not include client key when no clientInfo provided" do
+      request = {
+        jsonrpc: "2.0",
+        method: "ping",
+        id: 1,
+      }
+
+      @server.handle(request)
+      assert_instrumentation_data({ method: "ping" })
+    end
+
     test "#handle returns nil for notification requests" do
       request = {
         jsonrpc: "2.0",


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
Adding client information to the instrumentation callback. A follow-up to https://github.com/modelcontextprotocol/ruby-sdk/pull/218 of sorts. Client info is very helpful for analytics and debugging purposes.

## How Has This Been Tested?
Yes, tested with the Chattermill MCP (proprietary).

## Breaking Changes
No breaking changes 

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x ] My code follows the repository's style guidelines
- [ x] New and existing tests pass locally
- [ x] I have added appropriate error handling
- [ x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
