### PR TITLE
Extract `MCP::Annotations` into a dedicated file

### DIFF
--- a/lib/mcp.rb
+++ b/lib/mcp.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "json_rpc_handler"
+require_relative "mcp/annotations"
 require_relative "mcp/configuration"
 require_relative "mcp/content"
 require_relative "mcp/icon"
@@ -37,15 +38,6 @@ module MCP
 
     def configuration
       @configuration ||= Configuration.new
-    end
-  end
-
-  class Annotations
-    attr_reader :audience, :priority
-
-    def initialize(audience: nil, priority: nil)
-      @audience = audience
-      @priority = priority
     end
   end
 end

--- a/lib/mcp/annotations.rb
+++ b/lib/mcp/annotations.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module MCP
+  class Annotations
+    attr_reader :audience, :priority, :last_modified
+
+    def initialize(audience: nil, priority: nil, last_modified: nil)
+      @audience = audience
+      @priority = priority
+      @last_modified = last_modified
+    end
+
+    def to_h
+      {
+        audience: audience,
+        priority: priority,
+        lastModified: last_modified,
+      }.compact
+    end
+  end
+end

--- a/test/mcp/annotations_test.rb
+++ b/test/mcp/annotations_test.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module MCP
+  class AnnotationsTest < ActiveSupport::TestCase
+    def test_initialization
+      annotations = Annotations.new(audience: ["developers"], priority: 0.8)
+
+      assert_equal(["developers"], annotations.audience)
+      assert_equal(0.8, annotations.priority)
+      assert_nil(annotations.last_modified)
+
+      assert_equal({ audience: ["developers"], priority: 0.8 }, annotations.to_h)
+    end
+
+    def test_initialization_with_all_attributes
+      timestamp = Time.utc(2025, 1, 12, 15, 0, 58).iso8601
+      annotations = Annotations.new(audience: ["developers"], priority: 0.8, last_modified: timestamp)
+
+      assert_equal(["developers"], annotations.audience)
+      assert_equal(0.8, annotations.priority)
+      assert_equal(timestamp, annotations.last_modified)
+
+      assert_equal({ audience: ["developers"], priority: 0.8, lastModified: timestamp }, annotations.to_h)
+    end
+
+    def test_initialization_by_default
+      annotations = Annotations.new
+
+      assert_nil(annotations.audience)
+      assert_nil(annotations.priority)
+      assert_nil(annotations.last_modified)
+
+      assert_empty(annotations.to_h)
+    end
+
+    def test_initialization_with_partial_attributes
+      annotations = Annotations.new(audience: ["developers"])
+
+      assert_equal(["developers"], annotations.audience)
+      assert_nil(annotations.priority)
+      assert_nil(annotations.last_modified)
+
+      assert_equal({ audience: ["developers"] }, annotations.to_h)
+    end
+
+    def test_initialization_with_last_modified_only
+      timestamp = Time.utc(2025, 1, 12, 15, 0, 58).iso8601
+      annotations = Annotations.new(last_modified: timestamp)
+
+      assert_nil(annotations.audience)
+      assert_nil(annotations.priority)
+      assert_equal(timestamp, annotations.last_modified)
+
+      assert_equal({ lastModified: timestamp }, annotations.to_h)
+    end
+  end
+end


### PR DESCRIPTION
## Motivation and Context

This PR moves `MCP::Annotations` from lib/mcp.rb to lib/mcp/annotations.rb for better organization, following the pattern used for other classes such as `Tool::Annotations`.

This PR also adds the missing `last_modified` attribute to `MCP::Annotations`: https://github.com/modelcontextprotocol/modelcontextprotocol/blob/main/schema/2025-11-25/schema.ts#L1701-L1736

It also adds a `to_h` method for serialization and includes comprehensive test coverage.

## How Has This Been Tested?

Added comprehensive tests to verify the fix and prevent regression.

## Breaking Changes

None. This code is unused within the ruby-sdk repository, but it is kept for compatibility, as it may be used by users.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
