### PR TITLE
Add resource_templates to MCP::Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -953,6 +953,7 @@ This class supports:
 - Tool listing via the `tools/list` method (`MCP::Client#tools`)
 - Tool invocation via the `tools/call` method (`MCP::Client#call_tools`)
 - Resource listing via the `resources/list` method (`MCP::Client#resources`)
+- Resource template listing via the `resources/templates/list` method (`MCP::Client#resource_templates`)
 - Resource reading via the `resources/read` method (`MCP::Client#read_resources`)
 - Prompt listing via the `prompts/list` method (`MCP::Client#prompts`)
 - Prompt retrieval via the `prompts/get` method (`MCP::Client#get_prompt`)

--- a/lib/mcp/client.rb
+++ b/lib/mcp/client.rb
@@ -58,6 +58,20 @@ module MCP
       response.dig("result", "resources") || []
     end
 
+    # Returns the list of resource templates available from the server.
+    # Each call will make a new request – the result is not cached.
+    #
+    # @return [Array<Hash>] An array of available resource templates.
+    def resource_templates
+      response = transport.send_request(request: {
+        jsonrpc: JsonRpcHandler::Version::V2_0,
+        id: request_id,
+        method: "resources/templates/list",
+      })
+
+      response.dig("result", "resourceTemplates") || []
+    end
+
     # Returns the list of prompts available from the server.
     # Each call will make a new request – the result is not cached.
     #

--- a/test/mcp/client_test.rb
+++ b/test/mcp/client_test.rb
@@ -145,6 +145,43 @@ module MCP
       assert_empty(contents)
     end
 
+    def test_resource_templates_sends_request_to_transport_and_returns_resource_templates_array
+      transport = mock
+      mock_response = {
+        "result" => {
+          "resourceTemplates" => [
+            { "name" => "template1", "uriTemplate" => "file:///path/{filename}", "description" => "First template" },
+            { "name" => "template2", "uriTemplate" => "http://example.com/{id}", "description" => "Second template" },
+          ],
+        },
+      }
+
+      transport.expects(:send_request).with do |args|
+        args.dig(:request, :method) == "resources/templates/list" && args.dig(:request, :jsonrpc) == "2.0"
+      end.returns(mock_response).once
+
+      client = Client.new(transport: transport)
+      resource_templates = client.resource_templates
+
+      assert_equal(2, resource_templates.size)
+      assert_equal("template1", resource_templates.first["name"])
+      assert_equal("file:///path/{filename}", resource_templates.first["uriTemplate"])
+      assert_equal("template2", resource_templates.last["name"])
+      assert_equal("http://example.com/{id}", resource_templates.last["uriTemplate"])
+    end
+
+    def test_resource_templates_returns_empty_array_when_no_resource_templates
+      transport = mock
+      mock_response = { "result" => { "resourceTemplates" => [] } }
+
+      transport.expects(:send_request).returns(mock_response).once
+
+      client = Client.new(transport: transport)
+      resource_templates = client.resource_templates
+
+      assert_empty(resource_templates)
+    end
+
     def test_prompts_sends_request_to_transport_and_returns_prompts_array
       transport = mock
       mock_response = {


### PR DESCRIPTION
This adds support for querying resource templates to the MCP::Client

~~I also removed an unused require from `logging_message_notification.rb`~~

## Motivation and Context
Prior there was no MCP::Client interface for listing resource templates

## How Has This Been Tested?
I tested it with the following script with an mcp server I have:
```ruby
require_relative 'lib/mcp'

transport = MCP::Client::HTTP.new(url: "http://localhost:8080/mcp")
client = MCP::Client.new(transport: transport)

templates = client.resource_templates

templates.each do |template|
  puts JSON.pretty_generate(template)
end
```

And added tests to `test/mcp/client_test.rb`

## Breaking Changes
No breaking changes, just the new method

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
