### PR TITLE
Remove unused require from logging_message_notification.rb

### DIFF
--- a/lib/mcp/logging_message_notification.rb
+++ b/lib/mcp/logging_message_notification.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "json_rpc_handler"
-
 module MCP
   class LoggingMessageNotification
     LOG_LEVEL_SEVERITY = {


### PR DESCRIPTION
Removes an unused require from `logging_message_notification.rb`

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

## How Has This Been Tested?
Just with `rake`

## Breaking Changes
None

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
Originally tried to sneak this in in #225...
