### PR TITLE
Fix `logging/setLevel` to return empty hash per MCP specification

### DIFF
--- a/lib/mcp/server.rb
+++ b/lib/mcp/server.rb
@@ -362,6 +362,8 @@ module MCP
       end
 
       @logging_message_notification = logging_message_notification
+
+      {}
     end
 
     def list_tools(request)

--- a/test/mcp/server_test.rb
+++ b/test/mcp/server_test.rb
@@ -810,6 +810,24 @@ module MCP
       assert_instrumentation_data({ method: "resources/templates/list" })
     end
 
+    test "#configure_logging_level returns empty hash on success" do
+      response = @server.handle(
+        {
+          jsonrpc: "2.0",
+          id: 1,
+          method: "logging/setLevel",
+          params: {
+            level: "info",
+          },
+        },
+      )
+
+      assert_equal "2.0", response[:jsonrpc]
+      assert_equal 1, response[:id]
+      assert_empty(response[:result])
+      refute response.key?(:error)
+    end
+
     test "#configure_logging_level returns an error object when invalid log level is provided" do
       server = Server.new(
         tools: [TestTool],


### PR DESCRIPTION
## Motivation and Context

This PR fixes `logging/setLevel` to return empty hash per MCP specification. The MCP specification requires `logging/setLevel` to return an empty result on success, not nil or the `LoggingMessageNotification` object. Specification reference:
https://modelcontextprotocol.io/specification/2025-11-25/server/utilities/logging

Fixes #229.

## How Has This Been Tested?

Added a repro test to verify the fix and prevent regression.

## Breaking Changes

None.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

