### PR TITLE
Return JSON-RPC protocol errors for unknown tool calls

### DIFF
--- a/lib/mcp/server.rb
+++ b/lib/mcp/server.rb
@@ -377,7 +377,7 @@ module MCP
       unless tool
         add_instrumentation_data(tool_name: tool_name, error: :tool_not_found)
 
-        return error_tool_response("Tool not found: #{tool_name}")
+        raise RequestHandlerError.new("Tool not found: #{tool_name}", request, error_type: :invalid_params)
       end
 
       arguments = request[:arguments] || {}
@@ -401,6 +401,8 @@ module MCP
       end
 
       call_tool_with_args(tool, arguments)
+    rescue RequestHandlerError
+      raise
     rescue => e
       report_exception(e, request: request)
 


### PR DESCRIPTION
## Motivation and Context

Per the MCP specification, an unknown tool call is a protocol-level error, not a tool execution error. Return JSON-RPC -32602 (Invalid params) instead of successful responses with `isError: true`. https://modelcontextprotocol.io/specification/2025-11-25/server/tools#error-handling

Fixes #228.

## How Has This Been Tested?

Added a repro test to verify the fix and prevent regression.

## Breaking Changes

None.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
