### PR TITLE
Fix `Resource::Contents#to_h` to use correct property names per MCP spec

### DIFF
--- a/lib/mcp/resource/contents.rb
+++ b/lib/mcp/resource/contents.rb
@@ -11,7 +11,7 @@ module MCP
       end
 
       def to_h
-        { uri: uri, mime_type: mime_type }.compact
+        { uri: uri, mimeType: mime_type }.compact
       end
     end
 
@@ -37,7 +37,7 @@ module MCP
       end
 
       def to_h
-        super.merge(data: data)
+        super.merge(blob: data)
       end
     end
   end

--- a/test/mcp/resource/contents_test.rb
+++ b/test/mcp/resource/contents_test.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module MCP
+  class Resource
+    class ContentsTest < ActiveSupport::TestCase
+      test "Contents#to_h returns hash with mimeType" do
+        contents = Resource::Contents.new(
+          uri: "test://example",
+          mime_type: "text/plain",
+        )
+
+        result = contents.to_h
+
+        assert_equal "test://example", result[:uri]
+        assert_equal "text/plain", result[:mimeType]
+        refute result.key?(:mime_type), "Should use camelCase 'mimeType' not snake_case 'mime_type'"
+      end
+
+      test "Contents#to_h omits mimeType when nil" do
+        contents = Resource::Contents.new(uri: "test://example")
+
+        result = contents.to_h
+
+        assert_equal({ uri: "test://example" }, result)
+        refute result.key?(:mimeType)
+      end
+
+      test "TextContents#to_h returns hash with text and mimeType" do
+        text_contents = Resource::TextContents.new(
+          uri: "test://text",
+          mime_type: "text/plain",
+          text: "Hello, world!",
+        )
+
+        result = text_contents.to_h
+
+        assert_equal "test://text", result[:uri]
+        assert_equal "text/plain", result[:mimeType]
+        assert_equal "Hello, world!", result[:text]
+        refute result.key?(:mime_type), "Should use camelCase 'mimeType' not snake_case 'mime_type'"
+      end
+
+      test "BlobContents#to_h returns hash with blob and mimeType" do
+        blob_contents = Resource::BlobContents.new(
+          uri: "test://binary",
+          mime_type: "image/png",
+          data: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
+        )
+
+        result = blob_contents.to_h
+
+        assert_equal "test://binary", result[:uri]
+        assert_equal "image/png", result[:mimeType]
+        assert_equal "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==", result[:blob]
+        refute result.key?(:data), "Should use 'blob' not 'data' per MCP specification"
+        refute result.key?(:mime_type), "Should use camelCase 'mimeType' not snake_case 'mime_type'"
+      end
+
+      test "BlobContents#to_h omits mimeType when nil" do
+        blob_contents = Resource::BlobContents.new(
+          uri: "test://binary",
+          mime_type: nil,
+          data: "base64data",
+        )
+
+        result = blob_contents.to_h
+
+        assert_equal({ uri: "test://binary", blob: "base64data" }, result)
+        refute result.key?(:mimeType)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Motivation and Context

This PR fixes thr following fields with the MCP specification which requires:

- Text resources use `text` and `mimeType` fields
- Binary resources use `blob` (base64-encoded) and `mimeType` fields

https://modelcontextprotocol.io/specification/2025-11-25/server/resources#resource-contents

Fixes #234.

## How Has This Been Tested?

Added a repro test to verify the fix and prevent regression.

## Breaking Changes

None.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
