### PR TITLE
Replace `assert_empty` with `assert_equal` using explicit literals

### DIFF
--- a/test/mcp/annotations_test.rb
+++ b/test/mcp/annotations_test.rb
@@ -32,7 +32,7 @@ module MCP
       assert_nil(annotations.priority)
       assert_nil(annotations.last_modified)
 
-      assert_empty(annotations.to_h)
+      assert_equal({}, annotations.to_h)
     end
 
     def test_initialization_with_partial_attributes

--- a/test/mcp/client_test.rb
+++ b/test/mcp/client_test.rb
@@ -41,7 +41,7 @@ module MCP
       client = Client.new(transport: transport)
       tools = client.tools
 
-      assert_empty(tools)
+      assert_equal([], tools)
     end
 
     def test_call_tool_sends_request_to_transport_and_returns_content
@@ -102,7 +102,7 @@ module MCP
       client = Client.new(transport: transport)
       resources = client.resources
 
-      assert_empty(resources)
+      assert_equal([], resources)
     end
 
     def test_read_resource_sends_request_to_transport_and_returns_contents
@@ -142,7 +142,7 @@ module MCP
       client = Client.new(transport: transport)
       contents = client.read_resource(uri: uri)
 
-      assert_empty(contents)
+      assert_equal([], contents)
     end
 
     def test_resource_templates_sends_request_to_transport_and_returns_resource_templates_array
@@ -179,7 +179,7 @@ module MCP
       client = Client.new(transport: transport)
       resource_templates = client.resource_templates
 
-      assert_empty(resource_templates)
+      assert_equal([], resource_templates)
     end
 
     def test_prompts_sends_request_to_transport_and_returns_prompts_array
@@ -244,7 +244,7 @@ module MCP
       client = Client.new(transport: transport)
       prompts = client.prompts
 
-      assert_empty(prompts)
+      assert_equal([], prompts)
     end
 
     def test_get_prompt_sends_request_to_transport_and_returns_contents
@@ -290,7 +290,7 @@ module MCP
       client = Client.new(transport: transport)
       contents = client.get_prompt(name: name)
 
-      assert_empty(contents)
+      assert_equal({}, contents)
     end
 
     def test_get_prompt_returns_empty_hash
@@ -303,7 +303,7 @@ module MCP
       client = Client.new(transport: transport)
       contents = client.get_prompt(name: name)
 
-      assert_empty(contents)
+      assert_equal({}, contents)
     end
   end
 end

--- a/test/mcp/icon_test.rb
+++ b/test/mcp/icon_test.rb
@@ -23,7 +23,7 @@ module MCP
       assert_nil(icon.src)
       assert_nil(icon.theme)
 
-      assert_empty(icon.to_h)
+      assert_equal({}, icon.to_h)
     end
 
     def test_valid_theme_for_light

--- a/test/mcp/server/transports/stdio_notification_integration_test.rb
+++ b/test/mcp/server/transports/stdio_notification_integration_test.rb
@@ -213,7 +213,7 @@ module MCP
           # This test verifies the complete integration from server to transport
 
           # Start with no output
-          assert_empty @mock_stdout.output
+          assert_equal([], @mock_stdout.output)
 
           # Add a prompt and notify
           @server.define_prompt(

--- a/test/mcp/server/transports/stdio_transport_test.rb
+++ b/test/mcp/server/transports/stdio_transport_test.rb
@@ -45,7 +45,7 @@ module MCP
             response = JSON.parse(output.string, symbolize_names: true)
             assert_equal("2.0", response[:jsonrpc])
             assert_equal("123", response[:id])
-            assert_empty(response[:result])
+            assert_equal({}, response[:result])
             refute(@transport.instance_variable_get(:@open))
           ensure
             $stdin = original_stdin

--- a/test/mcp/server/transports/streamable_http_transport_test.rb
+++ b/test/mcp/server/transports/streamable_http_transport_test.rb
@@ -46,7 +46,7 @@ module MCP
           body = JSON.parse(response[2][0])
           assert_equal "2.0", body["jsonrpc"]
           assert_equal "123", body["id"]
-          assert_empty(body["result"])
+          assert_equal({}, body["result"])
         end
 
         test "handles POST request with invalid JSON" do
@@ -315,7 +315,7 @@ module MCP
           @transport.close
 
           # Verify session was cleaned up
-          assert_empty @transport.instance_variable_get(:@sessions)
+          assert_equal({}, @transport.instance_variable_get(:@sessions))
         end
 
         test "sends notification to correct session with multiple active sessions" do
@@ -847,7 +847,7 @@ module MCP
 
           response = stateless_transport.handle_request(request)
           assert_equal 202, response[0]
-          assert_empty(response[1])
+          assert_equal({}, response[1])
 
           body = response[2][0]
           assert_nil(body)
@@ -896,8 +896,8 @@ module MCP
 
           response = @transport.handle_request(notif_request)
           assert_equal 202, response[0]
-          assert_empty(response[1])
-          assert_empty(response[2])
+          assert_equal({}, response[1])
+          assert_equal([], response[2])
         end
 
         test "handles POST request with body including JSON-RPC response object and returns with no body" do
@@ -922,8 +922,8 @@ module MCP
 
           response = @transport.handle_request(request)
           assert_equal 202, response[0]
-          assert_empty(response[1])
-          assert_empty(response[2])
+          assert_equal({}, response[1])
+          assert_equal([], response[2])
         end
 
         private

--- a/test/mcp/server_test.rb
+++ b/test/mcp/server_test.rb
@@ -824,7 +824,7 @@ module MCP
 
       assert_equal "2.0", response[:jsonrpc]
       assert_equal 1, response[:id]
-      assert_empty(response[:result])
+      assert_equal({}, response[:result])
       refute response.key?(:error)
     end
 

--- a/test/mcp/tool/input_schema_test.rb
+++ b/test/mcp/tool/input_schema_test.rb
@@ -33,7 +33,7 @@ module MCP
 
       test "missing_required_arguments returns an empty array if no required arguments are missing" do
         input_schema = InputSchema.new(properties: { message: { type: "string" } }, required: ["message"])
-        assert_empty input_schema.missing_required_arguments({ message: "Hello, world!" })
+        assert_equal([], input_schema.missing_required_arguments({ message: "Hello, world!" }))
       end
 
       test "valid schema initialization" do

--- a/test/mcp/tool/response_test.rb
+++ b/test/mcp/tool/response_test.rb
@@ -107,7 +107,7 @@ module MCP
         actual = response.to_h
 
         assert_equal [:content, :isError, :structuredContent], actual.keys
-        assert_empty actual[:content]
+        assert_equal([], actual[:content])
         assert_equal structured_content, actual[:structuredContent]
         refute actual[:isError]
       end
@@ -118,7 +118,7 @@ module MCP
         actual = response.to_h
 
         assert_equal [:content, :isError, :structuredContent], actual.keys
-        assert_empty actual[:content]
+        assert_equal([], actual[:content])
         assert_equal structured_content, actual[:structuredContent]
         refute actual[:isError]
       end


### PR DESCRIPTION
## Motivation and Context

Due to overly aggressive detection by RuboCop Minitest, the distinction between `[]` and `{}` was uniformly replaced with `assert_empty`, making it impossible to differentiate between them. As a result of https://github.com/rubocop/rubocop-minitest/issues/344, where the `Minitest/AssertEmptyLiteral` cop was disabled, the return value has been expressed using explicit literal forms.

## How Has This Been Tested?

Existing tests pass.

## Breaking Changes

None.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
