### PR TITLE
Reduce release package size

### DIFF
--- a/mcp.gemspec
+++ b/mcp.gemspec
@@ -23,9 +23,7 @@ Gem::Specification.new do |spec|
   spec.metadata["bug_tracker_uri"] = "#{spec.homepage}/issues"
   spec.metadata["documentation_uri"] = "https://rubydoc.info/gems/mcp"
 
-  spec.files = Dir.chdir(File.expand_path("..", __FILE__)) do
-    %x(git ls-files -z).split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
-  end
+  spec.files = Dir["LICENSE", "README.md", "lib/**/*"]
 
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }


### PR DESCRIPTION
## Motivation and Context

The current release package contains files that are not required at runtime, such as `.github`, `docs`, and `examples`.

```ruby
Dir.chdir(File.expand_path("..", __FILE__)) do
  %x(git ls-files -z).split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
end
=>
[".gitattributes",
 ".github/dependabot.yml",
 ".github/workflows/ci.yml",
 ".github/workflows/release.yml",
 ".gitignore",
 ".rubocop.yml",
 "AGENTS.md",
 "CHANGELOG.md",
 "CODE_OF_CONDUCT.md",
 "Gemfile",
 "LICENSE",
(snip)
```

This PR removes unnecessary files where possible to reduce the size of the release package.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
