### PR TITLE
Add `*.gem` to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .ruby-version
+/*.gem
 /.bundle/
 /.yardoc
 /_yardoc/


### PR DESCRIPTION
## Motivation and Context

`gem build mcp.gemspec` outputs the built gem into the working directory (e.g. mcp-0.7.1.gem) rather than pkg/, which is already ignored.
Without this entry, the file shows up as an untracked file and risks being accidentally staged and committed during release preparation or local development.

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
