### PR TITLE
Fix `Content::Image#to_h` to return `mimeType` (camelCase) per MCP spec

### DIFF
--- a/lib/mcp/content.rb
+++ b/lib/mcp/content.rb
@@ -25,7 +25,7 @@ module MCP
       end
 
       def to_h
-        { data: data, mime_type: mime_type, annotations: annotations, type: "image" }.compact
+        { data: data, mimeType: mime_type, annotations: annotations, type: "image" }.compact
       end
     end
   end

--- a/test/mcp/content_test.rb
+++ b/test/mcp/content_test.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module MCP
+  module Content
+    class ImageTest < ActiveSupport::TestCase
+      test "#to_h returns mimeType (camelCase) per MCP spec" do
+        image = Image.new("base64data", "image/png")
+        result = image.to_h
+
+        assert_equal "image/png", result[:mimeType]
+        refute result.key?(:mime_type), "Expected camelCase mimeType, got snake_case mime_type"
+        assert_equal "image", result[:type]
+        assert_equal "base64data", result[:data]
+      end
+
+      test "#to_h with annotations" do
+        image = Image.new("base64data", "image/png", annotations: { role: "thumbnail" })
+        result = image.to_h
+
+        assert_equal({ role: "thumbnail" }, result[:annotations])
+      end
+
+      test "#to_h without annotations omits the key" do
+        image = Image.new("base64data", "image/png")
+        result = image.to_h
+
+        refute result.key?(:annotations)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Motivation and Context

This is a fix for a similar bug that remained, as in #235.

`Content::Image#to_h` returned `mime_type` (snake_case), but the MCP spec requires `mimeType` (camelCase) for the MIME type field in image content.

## How Has This Been Tested?

Added a repro test to verify the fix and prevent regression.

## Breaking Changes

None. This fixes behavior that was incorrect with respect to the specification.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
