### PR TITLE
Allow `$ref` in `Tool::Schema` for protocol version 2025-11-25

### DIFF
--- a/lib/mcp/tool/schema.rb
+++ b/lib/mcp/tool/schema.rb
@@ -31,10 +31,6 @@ module MCP
         case schema
         when Hash
           schema.each_with_object({}) do |(key, value), result|
-            if key.casecmp?("$ref")
-              raise ArgumentError, "Invalid JSON Schema: $ref is not allowed in tool schemas"
-            end
-
             result[yield(key)] = deep_transform_keys(value, &block)
           end
         when Array

--- a/test/mcp/tool/input_schema_test.rb
+++ b/test/mcp/tool/input_schema_test.rb
@@ -92,16 +92,41 @@ module MCP
         end
       end
 
-      test "rejects schemas with $ref references" do
-        assert_raises(ArgumentError) do
-          InputSchema.new(properties: { foo: { "$ref" => "#/definitions/bar" } }, required: ["foo"])
-        end
+      test "accepts schemas with $ref references" do
+        schema = InputSchema.new(
+          properties: {
+            foo: { type: "string" },
+          },
+          definitions: {
+            bar: { type: "string" },
+          },
+          required: ["foo"],
+        )
+        assert_includes schema.to_h.keys, :definitions
       end
 
-      test "rejects schemas with symbol $ref references" do
-        assert_raises(ArgumentError) do
-          InputSchema.new(properties: { foo: { :$ref => "#/definitions/bar" } }, required: ["foo"])
-        end
+      test "accepts schemas with $ref string key and includes $ref in to_h" do
+        schema = InputSchema.new({
+          "properties" => {
+            "foo" => { "$ref" => "#/definitions/bar" },
+          },
+          "definitions" => {
+            "bar" => { "type" => "string" },
+          },
+        })
+        assert_equal "#/definitions/bar", schema.to_h[:properties][:foo][:$ref]
+      end
+
+      test "accepts schemas with $ref symbol key and includes $ref in to_h" do
+        schema = InputSchema.new({
+          properties: {
+            foo: { :$ref => "#/definitions/bar" },
+          },
+          definitions: {
+            bar: { type: "string" },
+          },
+        })
+        assert_equal "#/definitions/bar", schema.to_h[:properties][:foo][:$ref]
       end
 
       test "== compares two input schemas with the same properties, required fields" do

--- a/test/mcp/tool/output_schema_test.rb
+++ b/test/mcp/tool/output_schema_test.rb
@@ -82,16 +82,41 @@ module MCP
         end
       end
 
-      test "rejects schemas with $ref references" do
-        assert_raises(ArgumentError) do
-          OutputSchema.new(properties: { foo: { "$ref" => "#/definitions/bar" } }, required: ["foo"])
-        end
+      test "accepts schemas with $ref references" do
+        schema = OutputSchema.new(
+          properties: {
+            foo: { type: "string" },
+          },
+          definitions: {
+            bar: { type: "string" },
+          },
+          required: ["foo"],
+        )
+        assert_includes schema.to_h.keys, :definitions
       end
 
-      test "rejects schemas with symbol $ref references" do
-        assert_raises(ArgumentError) do
-          OutputSchema.new(properties: { foo: { :$ref => "#/definitions/bar" } }, required: ["foo"])
-        end
+      test "accepts schemas with $ref string key and includes $ref in to_h" do
+        schema = OutputSchema.new({
+          "properties" => {
+            "foo" => { "$ref" => "#/definitions/bar" },
+          },
+          "definitions" => {
+            "bar" => { "type" => "string" },
+          },
+        })
+        assert_equal "#/definitions/bar", schema.to_h[:properties][:foo][:$ref]
+      end
+
+      test "accepts schemas with $ref symbol key and includes $ref in to_h" do
+        schema = OutputSchema.new({
+          properties: {
+            foo: { :$ref => "#/definitions/bar" },
+          },
+          definitions: {
+            bar: { type: "string" },
+          },
+        })
+        assert_equal "#/definitions/bar", schema.to_h[:properties][:foo][:$ref]
       end
 
       test "== compares two output schemas with the same properties and required fields" do

--- a/test/mcp/tool_test.rb
+++ b/test/mcp/tool_test.rb
@@ -320,7 +320,7 @@ module MCP
       assert_equal [{ type: "text", content: "OK" }], response.content
     end
 
-    test "input_schema rejects any $ref in schema" do
+    test "input_schema accepts $ref in schema" do
       schema_with_ref = {
         properties: {
           foo: { "$ref" => "#/definitions/bar" },
@@ -330,12 +330,10 @@ module MCP
           bar: { type: "string" },
         },
       }
-      error = assert_raises(ArgumentError) do
-        Class.new(MCP::Tool) do
-          input_schema schema_with_ref
-        end
+      tool_class = Class.new(MCP::Tool) do
+        input_schema schema_with_ref
       end
-      assert_match(/Invalid JSON Schema/, error.message)
+      assert_equal "#/definitions/bar", tool_class.input_schema.to_h[:properties][:foo][:$ref]
     end
 
     test "#to_h includes outputSchema when present" do
@@ -409,7 +407,7 @@ module MCP
       assert_includes error.message, "string did not match the following type: number"
     end
 
-    test "output_schema rejects any $ref in schema" do
+    test "output_schema accepts $ref in schema" do
       schema_with_ref = {
         properties: {
           foo: { "$ref" => "#/definitions/bar" },
@@ -419,12 +417,10 @@ module MCP
           bar: { type: "string" },
         },
       }
-      error = assert_raises(ArgumentError) do
-        Class.new(MCP::Tool) do
-          output_schema schema_with_ref
-        end
+      tool_class = Class.new(MCP::Tool) do
+        output_schema schema_with_ref
       end
-      assert_match(/Invalid JSON Schema/, error.message)
+      assert_equal "#/definitions/bar", tool_class.output_schema.to_h[:properties][:foo][:$ref]
     end
 
     test ".define allows definition of tools with output_schema" do


### PR DESCRIPTION
## Motivation and Context

`Tool::Schema` rejected `$ref` with an `ArgumentError`. Earlier MCP spec versions (2024-11-05 through 2025-06-18) did not define a JSON Schema dialect or reference the `$ref` keyword. `inputSchema` was described only as "JSON Schema defining expected parameters" with no further constraints:

- https://modelcontextprotocol.io/specification/2024-11-05/server/tools
- https://modelcontextprotocol.io/specification/2025-06-18/server/tools

The MCP spec 2025-11-25 introduced a "JSON Schema Usage" section that adopts JSON Schema 2020-12 as the default dialect. Since `$ref` is a core keyword in 2020-12, it is now allowed for protocol version 2025-11-25 and later.

- https://modelcontextprotocol.io/specification/2025-11-25/basic#json-schema-usage
- https://modelcontextprotocol.io/specification/2025-11-25/server/tools
- https://json-schema.org/draft/2020-12/release-notes

## How Has This Been Tested?

Added a repro test to verify the fix and prevent regression.

## Breaking Changes

None. For backward compatibility with older protocol versions (2025-06-18 and earlier), `Server#validate!` continues to raise `ArgumentError` when a tool input schema contains `$ref`. This preserves the existing behavior for servers targeting those spec versions.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
