### PR TITLE
Add `Content::Audio` class for audio content type

### DIFF
--- a/lib/mcp/content.rb
+++ b/lib/mcp/content.rb
@@ -28,5 +28,19 @@ module MCP
         { data: data, mimeType: mime_type, annotations: annotations, type: "image" }.compact
       end
     end
+
+    class Audio
+      attr_reader :data, :mime_type, :annotations
+
+      def initialize(data, mime_type, annotations: nil)
+        @data = data
+        @mime_type = mime_type
+        @annotations = annotations
+      end
+
+      def to_h
+        { data: data, mimeType: mime_type, annotations: annotations, type: "audio" }.compact
+      end
+    end
   end
 end

--- a/test/mcp/content_test.rb
+++ b/test/mcp/content_test.rb
@@ -29,5 +29,30 @@ module MCP
         refute result.key?(:annotations)
       end
     end
+
+    class AudioTest < ActiveSupport::TestCase
+      test "#to_h returns correct format per MCP spec" do
+        audio = Audio.new("base64data", "audio/wav")
+        result = audio.to_h
+
+        assert_equal "audio", result[:type]
+        assert_equal "base64data", result[:data]
+        assert_equal "audio/wav", result[:mimeType]
+      end
+
+      test "#to_h with annotations" do
+        audio = Audio.new("base64data", "audio/wav", annotations: { role: "recording" })
+        result = audio.to_h
+
+        assert_equal({ role: "recording" }, result[:annotations])
+      end
+
+      test "#to_h without annotations omits the key" do
+        audio = Audio.new("base64data", "audio/wav")
+        result = audio.to_h
+
+        refute result.key?(:annotations)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Motivation and Context

The MCP spec defines an audio content type, but the SDK only had `Content::Text` and `Content::Image`. Add `Content::Audio` with the same structure as `Content::Image`.

https://modelcontextprotocol.io/specification/2025-11-25/server/tools#audio-content

## How Has This Been Tested?

Pass the newly added tests.

## Breaking Changes

None.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
