### PR TITLE
Add `Content::EmbeddedResource` class for embedded resource content type

### DIFF
--- a/lib/mcp/content.rb
+++ b/lib/mcp/content.rb
@@ -42,5 +42,18 @@ module MCP
         { data: data, mimeType: mime_type, annotations: annotations, type: "audio" }.compact
       end
     end
+
+    class EmbeddedResource
+      attr_reader :resource, :annotations
+
+      def initialize(resource, annotations: nil)
+        @resource = resource
+        @annotations = annotations
+      end
+
+      def to_h
+        { resource: resource.to_h, annotations: annotations, type: "resource" }.compact
+      end
+    end
   end
 end

--- a/test/mcp/content_test.rb
+++ b/test/mcp/content_test.rb
@@ -54,5 +54,44 @@ module MCP
         refute result.key?(:annotations)
       end
     end
+
+    class EmbeddedResourceTest < ActiveSupport::TestCase
+      test "#to_h returns correct format per MCP spec" do
+        resource = Object.new
+        def resource.to_h
+          { uri: "test://example", mimeType: "text/plain", text: "content" }
+        end
+
+        embedded = EmbeddedResource.new(resource)
+        result = embedded.to_h
+
+        assert_equal "resource", result[:type]
+        assert_equal({ uri: "test://example", mimeType: "text/plain", text: "content" }, result[:resource])
+      end
+
+      test "#to_h with annotations" do
+        resource = Object.new
+        def resource.to_h
+          { uri: "test://x" }
+        end
+
+        embedded = EmbeddedResource.new(resource, annotations: { role: "data" })
+        result = embedded.to_h
+
+        assert_equal({ role: "data" }, result[:annotations])
+      end
+
+      test "#to_h without annotations omits the key" do
+        resource = Object.new
+        def resource.to_h
+          { uri: "test://x" }
+        end
+
+        embedded = EmbeddedResource.new(resource)
+        result = embedded.to_h
+
+        refute result.key?(:annotations)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Motivation and Context

The MCP spec defines an embedded resource content type, but the SDK had no corresponding class. Add `Content::EmbeddedResource` that wraps a resource object and serializes it via `to_h`.

https://modelcontextprotocol.io/specification/2025-11-25/server/tools#embedded-resources

## How Has This Been Tested?

Pass the newly added tests.

## Breaking Changes

None.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
