### PR TITLE
Return 202 Accepted for SSE responses per MCP spec

### DIFF
--- a/lib/mcp/server/transports/streamable_http_transport.rb
+++ b/lib/mcp/server/transports/streamable_http_transport.rb
@@ -288,7 +288,7 @@ module MCP
         def send_response_to_stream(stream, response, session_id)
           message = JSON.parse(response)
           send_to_stream(stream, message)
-          [200, { "Content-Type" => "application/json" }, [{ accepted: true }.to_json]]
+          handle_accepted
         rescue IOError, Errno::EPIPE => e
           MCP.configuration.exception_reporter.call(
             e,


### PR DESCRIPTION
## Motivation and Context

`StreamableHTTPTransport#send_response_to_stream` returned 200 with `{ accepted: true }` body, but the MCP spec requires 202 with empty body when a response is sent via SSE stream. This has been a requirement since Streamable HTTP was introduced in protocol version 2025-03-26.

- https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#sending-messages-to-the-server
- https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#sending-messages-to-the-server

## How Has This Been Tested?

Added a repro test to verify the fix and prevent regression.

## Breaking Changes

None. This fixes behavior that was incorrect with respect to the specification.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
