### PR TITLE
Fix `Prompt#validate_arguments!` crash when arguments are `nil`

### DIFF
--- a/lib/mcp/prompt.rb
+++ b/lib/mcp/prompt.rb
@@ -21,7 +21,7 @@ module MCP
           title: title_value,
           description: description_value,
           icons: icons_value&.then { |icons| icons.empty? ? nil : icons.map(&:to_h) },
-          arguments: arguments_value&.map(&:to_h),
+          arguments: arguments_value.empty? ? nil : arguments_value.map(&:to_h),
           _meta: meta_value,
         }.compact
       end
@@ -32,7 +32,7 @@ module MCP
         subclass.instance_variable_set(:@title_value, nil)
         subclass.instance_variable_set(:@description_value, nil)
         subclass.instance_variable_set(:@icons_value, nil)
-        subclass.instance_variable_set(:@arguments_value, nil)
+        subclass.instance_variable_set(:@arguments_value, [])
         subclass.instance_variable_set(:@meta_value, nil)
       end
 
@@ -76,7 +76,7 @@ module MCP
         if value == NOT_SET
           @arguments_value
         else
-          @arguments_value = value
+          @arguments_value = Array(value)
         end
       end
 
@@ -103,6 +103,7 @@ module MCP
       end
 
       def validate_arguments!(args)
+        args ||= {}
         missing = required_args - args.keys
         return if missing.empty?
 

--- a/test/mcp/prompt_test.rb
+++ b/test/mcp/prompt_test.rb
@@ -182,7 +182,7 @@ module MCP
       assert_equal expected, FullPrompt.to_h
     end
 
-    test "#to_h handles nil arguments value" do
+    test "#to_h omits arguments key when arguments are not declared" do
       class NoArgumentsPrompt < Prompt
         description "No arguments prompt"
       end
@@ -194,6 +194,51 @@ module MCP
       }
 
       assert_equal expected, prompt.to_h
+    end
+
+    test "#validate_arguments! does not raise when arguments are not declared" do
+      prompt_class = Class.new(Prompt) do
+        prompt_name "no_args_prompt"
+        description "A prompt with no arguments"
+        # NOTE: no `arguments` declaration at all
+      end
+
+      assert_nothing_raised do
+        prompt_class.validate_arguments!({})
+      end
+    end
+
+    test "#validate_arguments! handles nil args" do
+      prompt_class = Class.new(Prompt) do
+        prompt_name "no_args_prompt"
+        description "A prompt with no arguments"
+      end
+
+      assert_nothing_raised do
+        prompt_class.validate_arguments!(nil)
+      end
+    end
+
+    test "#validate_arguments! does not raise when arguments is explicitly set to nil" do
+      prompt_class = Class.new(Prompt) do
+        prompt_name "nil_args_prompt"
+        description "A prompt with nil arguments"
+        arguments nil
+      end
+
+      assert_nothing_raised do
+        prompt_class.validate_arguments!({})
+      end
+    end
+
+    test "#to_h omits arguments key when arguments is empty" do
+      prompt = Prompt.define(
+        name: "no_args_prompt",
+        description: "a prompt without arguments",
+        arguments: [],
+      )
+
+      refute prompt.to_h.key?(:arguments)
     end
 
     test "#to_h does not have `:icons` key when icons is empty" do


### PR DESCRIPTION
## Motivation and Context

`Prompt#validate_arguments!` called `required_args` which does `arguments_value.filter_map`, crashing with `NoMethodError` when `arguments_value` is `nil` (the default for prompts without declared arguments). Additionally, passing `nil` as args caused a crash on `args.keys`.

Fix by defaulting `arguments_value` to `[]` and guarding against `nil` args.

## How Has This Been Tested?

Added a repro test to verify the fix and prevent regression.

## Breaking Changes

None.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
