### PR TITLE
Fix default handler return values to comply with MCP spec

### DIFF
--- a/lib/mcp/server.rb
+++ b/lib/mcp/server.rb
@@ -99,9 +99,9 @@ module MCP
         Methods::LOGGING_SET_LEVEL => method(:configure_logging_level),
 
         # No op handlers for currently unsupported methods
-        Methods::RESOURCES_SUBSCRIBE => ->(_) {},
-        Methods::RESOURCES_UNSUBSCRIBE => ->(_) {},
-        Methods::COMPLETION_COMPLETE => ->(_) {},
+        Methods::RESOURCES_SUBSCRIBE => ->(_) { {} },
+        Methods::RESOURCES_UNSUBSCRIBE => ->(_) { {} },
+        Methods::COMPLETION_COMPLETE => ->(_) { { completion: { values: [], hasMore: false } } },
         Methods::ELICITATION_CREATE => ->(_) {},
       }
       @transport = transport

--- a/test/mcp/server_test.rb
+++ b/test/mcp/server_test.rb
@@ -1540,6 +1540,87 @@ module MCP
       assert_includes response[:result][:content][0][:text], "Invalid arguments"
     end
 
+    test "#handle completion/complete returns default completion result" do
+      server = Server.new(
+        name: "test_server",
+        capabilities: { completions: {} },
+      )
+
+      server.handle({ jsonrpc: "2.0", method: "initialize", id: 1 })
+      server.handle({ jsonrpc: "2.0", method: "notifications/initialized" })
+
+      response = server.handle({
+        jsonrpc: "2.0",
+        id: 2,
+        method: "completion/complete",
+        params: {
+          ref: { type: "ref/prompt", name: "test" },
+          argument: { name: "arg", value: "val" },
+        },
+      })
+
+      assert_equal(
+        {
+          jsonrpc: "2.0",
+          id: 2,
+          result: { completion: { values: [], hasMore: false } },
+        },
+        response,
+      )
+    end
+
+    test "#handle resources/subscribe returns empty result" do
+      server = Server.new(
+        name: "test_server",
+        capabilities: { resources: { subscribe: true } },
+      )
+
+      server.handle({ jsonrpc: "2.0", method: "initialize", id: 1 })
+      server.handle({ jsonrpc: "2.0", method: "notifications/initialized" })
+
+      response = server.handle({
+        jsonrpc: "2.0",
+        id: 2,
+        method: "resources/subscribe",
+        params: { uri: "https://example.com/resource" },
+      })
+
+      assert_equal(
+        {
+          jsonrpc: "2.0",
+          id: 2,
+          result: {},
+        },
+        response,
+      )
+    end
+
+    test "#handle resources/unsubscribe returns empty result" do
+      server = Server.new(
+        name: "test_server",
+        capabilities: { resources: { subscribe: true } },
+      )
+
+      server.handle({ jsonrpc: "2.0", method: "initialize", id: 1 })
+      server.handle({ jsonrpc: "2.0", method: "notifications/initialized" })
+
+      response = server.handle({
+        jsonrpc: "2.0",
+        id: 2,
+        method: "resources/unsubscribe",
+        params: { uri: "https://example.com/resource" },
+      })
+
+      assert_equal(
+        {
+          jsonrpc: "2.0",
+          id: 2,
+          result: {},
+        },
+        response,
+      )
+    end
+
     test "tools/call with no args" do
       server = Server.new(tools: [@tool_with_no_args])
 


### PR DESCRIPTION
## Motivation and Context

The no-op handlers for `completion/complete`, `resources/subscribe`, and `resources/unsubscribe` returned `nil`.
When a client accesses the expected response structure (e.g., `result[:completion][:values]`), a `nil` result raises `NoMethodError`.

The MCP spec requires specific response structures even for no-op handlers. Returning spec-compliant defaults ensures that clients receive valid responses without requiring servers to explicitly override each handler.

`completion/complete` now returns `{ completion: { values: [], hasMore: false } }`.
ref: https://modelcontextprotocol.io/specification/2025-11-25/server/utilities/completion

`resources/subscribe` and `resources/unsubscribe` now return `{}` (empty result). ref: https://modelcontextprotocol.io/specification/2025-11-25/server/resources#subscriptions

## How Has This Been Tested?

Added a repro test to verify the fix and prevent regression.

## Breaking Changes

None.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
