### PR TITLE
[Doc] Fix Rails controller example to return 202 for notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,11 +242,12 @@ When added to a Rails controller on a route that handles POST requests, your ser
 [Streamable HTTP](https://modelcontextprotocol.io/specification/latest/basic/transports#streamable-http) transport
 requests.
 
-You can use the `Server#handle_json` method to handle requests.
+You can use `StreamableHTTPTransport#handle_request` to handle requests with proper HTTP
+status codes (e.g., 202 Accepted for notifications).
 
 ```ruby
-class ApplicationController < ActionController::Base
-  def index
+class McpController < ActionController::Base
+  def create
     server = MCP::Server.new(
       name: "my_server",
       title: "Example Server Display Name",
@@ -256,7 +257,11 @@ class ApplicationController < ActionController::Base
       prompts: [MyPrompt],
       server_context: { user_id: current_user.id },
     )
-    render(json: server.handle_json(request.body.read))
+    transport = MCP::Server::Transports::StreamableHTTPTransport.new(server)
+    server.transport = transport
+    status, headers, body = transport.handle_request(request)
+
+    render(json: body.first, status: status, headers: headers)
   end
 end
 ```


### PR DESCRIPTION
## Motivation and Context

The previous example used `Server#handle_json` directly, which does not control HTTP status codes. Notifications such as `notifications/initialized` require 202 Accepted per the MCP spec, but the example always returned 200.

Use `StreamableHTTPTransport#handle_request` instead, which returns the correct HTTP status code for each request type.

- https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#sending-messages-to-the-server
- https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#sending-messages-to-the-server

Closes #158

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

