### PR TITLE
Support CORS and Accept wildcard for browser-based MCP clients

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem "rubocop-rake", require: false
 gem "rubocop-shopify", ">= 2.18", require: false if RUBY_VERSION >= "3.1"
 
 gem "puma", ">= 5.0.0"
+gem "rack-cors"
 gem "rackup", ">= 2.1.0"
 
 gem "activesupport"

--- a/examples/README.md
+++ b/examples/README.md
@@ -121,6 +121,31 @@ The client will:
 - Provide an interactive menu to trigger notifications
 - Display all received SSE events in real-time
 
+### Testing with MCP Inspector
+
+[MCP Inspector](https://modelcontextprotocol.io/docs/tools/inspector) is a browser-based tool for testing and debugging MCP servers.
+
+1. Start the server:
+
+```console
+$ ruby examples/streamable_http_server.rb
+```
+
+2. Start Inspector in another terminal:
+
+```console
+$ npx @modelcontextprotocol/inspector
+```
+
+3. Open `http://localhost:6274` in a browser:
+
+- Set Transport Type to "Streamable HTTP"
+- Set URL to `http://localhost:9393`
+- Disable the Authorization header toggle (the example server does not require authentication)
+- Click "Connect"
+
+Once connected, you can list tools, call them, and see SSE notifications in the Inspector UI.
+
 ### Testing SSE with cURL
 
 You can also test SSE functionality manually using cURL:

--- a/examples/http_server.rb
+++ b/examples/http_server.rb
@@ -2,6 +2,7 @@
 
 $LOAD_PATH.unshift(File.expand_path("../lib", __dir__))
 require "mcp"
+require "rack/cors"
 require "rackup"
 require "json"
 require "logger"
@@ -142,6 +143,20 @@ end
 
 # Wrap the app with Rack middleware
 rack_app = Rack::Builder.new do
+  # Enable CORS to allow browser-based MCP clients (e.g., MCP Inspector)
+  # WARNING: origins("*") allows all origins. Restrict this in production.
+  use(Rack::Cors) do
+    allow do
+      origins("*")
+      resource(
+        "*",
+        headers: :any,
+        methods: [:get, :post, :delete, :options],
+        expose: ["Mcp-Session-Id"],
+      )
+    end
+  end
+
   # Use CommonLogger for standard HTTP request logging
   use(Rack::CommonLogger, Logger.new($stdout))
 

--- a/examples/streamable_http_server.rb
+++ b/examples/streamable_http_server.rb
@@ -2,6 +2,7 @@
 
 $LOAD_PATH.unshift(File.expand_path("../lib", __dir__))
 require "mcp"
+require "rack/cors"
 require "rackup"
 require "json"
 require "logger"
@@ -129,6 +130,20 @@ end
 
 # Build the Rack application with middleware
 rack_app = Rack::Builder.new do
+  # Enable CORS to allow browser-based MCP clients (e.g., MCP Inspector)
+  # WARNING: origins("*") allows all origins. Restrict this in production.
+  use(Rack::Cors) do
+    allow do
+      origins("*")
+      resource(
+        "*",
+        headers: :any,
+        methods: [:get, :post, :delete, :options],
+        expose: ["Mcp-Session-Id"],
+      )
+    end
+  end
+
   use(Rack::CommonLogger, Logger.new($stdout))
   use(Rack::ShowExceptions)
   run(app)

--- a/lib/mcp/server/transports/streamable_http_transport.rb
+++ b/lib/mcp/server/transports/streamable_http_transport.rb
@@ -193,6 +193,8 @@ module MCP
           return not_acceptable_response(required_types) unless accept_header
 
           accepted_types = parse_accept_header(accept_header)
+          return if accepted_types.include?("*/*")
+
           missing_types = required_types - accepted_types
           return not_acceptable_response(required_types) unless missing_types.empty?
 

--- a/test/mcp/server/transports/streamable_http_transport_test.rb
+++ b/test/mcp/server/transports/streamable_http_transport_test.rb
@@ -855,6 +855,21 @@ module MCP
           assert_equal 200, response[0]
         end
 
+        test "POST request with Accept: */* succeeds" do
+          request = create_rack_request_without_accept(
+            "POST",
+            "/",
+            {
+              "CONTENT_TYPE" => "application/json",
+              "HTTP_ACCEPT" => "*/*",
+            },
+            { jsonrpc: "2.0", method: "initialize", id: "123" }.to_json,
+          )
+
+          response = @transport.handle_request(request)
+          assert_equal 200, response[0]
+        end
+
         test "GET request without Accept header returns 406" do
           init_request = create_rack_request(
             "POST",
@@ -920,6 +935,30 @@ module MCP
             {
               "HTTP_MCP_SESSION_ID" => session_id,
               "HTTP_ACCEPT" => "text/event-stream",
+            },
+          )
+
+          response = @transport.handle_request(request)
+          assert_equal 200, response[0]
+          assert_equal "text/event-stream", response[1]["Content-Type"]
+        end
+
+        test "GET request with Accept: */* succeeds" do
+          init_request = create_rack_request(
+            "POST",
+            "/",
+            { "CONTENT_TYPE" => "application/json" },
+            { jsonrpc: "2.0", method: "initialize", id: "123" }.to_json,
+          )
+          init_response = @transport.handle_request(init_request)
+          session_id = init_response[1]["Mcp-Session-Id"]
+
+          request = create_rack_request_without_accept(
+            "GET",
+            "/",
+            {
+              "HTTP_MCP_SESSION_ID" => session_id,
+              "HTTP_ACCEPT" => "*/*",
             },
           )
 


### PR DESCRIPTION
## Motivation and Context

When using browser-based MCP clients such as MCP Inspector, connections to the example HTTP server failed due to two issues:

1. CORS preflight (OPTIONS) requests returned 405 Method Not Allowed, causing browsers to block all cross-origin requests.
2. `Accept: */*` (commonly sent by browsers and fetch API) returned 406 Not Acceptable because the transport required the Accept header to explicitly list `application/json` and `text/event-stream`.

Add `rack-cors` middleware to the example HTTP servers so that preflight requests are handled correctly and `Mcp-Session-Id` is exposed to browser clients. Also fix `validate_accept_header` in `StreamableHTTPTransport` to treat `*/*` as satisfying all required Accept types.

Fixes #141.

## How Has This Been Tested?

Repro Steps:

### 1. Start the example server (Terminal 1)

```console
$ bundle exec ruby examples/streamable_http_server.rb
```

### 2. Start MCP Inspector (Terminal 2)

```console
$ npx @modelcontextprotocol/inspector
```

### 3. Open the Inspector Web UI (http://localhost:6274) in a browser

- Set Transport Type to "Streamable HTTP"
- Set URL to http://localhost:9393
- Disable the Authorization header toggle (the example server does not require authentication)
- Click "Connect"

Before this change, the connection fails due to CORS or 406 errors. After this change, the connection succeeds and tools are listed.

These steps have been added to examples/README.md.

## Breaking Changes

None.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

