### PR TITLE
Use `autoload` to defer loading of unused subsystems

### DIFF
--- a/lib/mcp.rb
+++ b/lib/mcp.rb
@@ -1,38 +1,22 @@
 # frozen_string_literal: true
 
 require_relative "json_rpc_handler"
-require_relative "mcp/annotations"
 require_relative "mcp/configuration"
-require_relative "mcp/content"
-require_relative "mcp/icon"
-require_relative "mcp/instrumentation"
-require_relative "mcp/methods"
-require_relative "mcp/progress"
-require_relative "mcp/prompt"
-require_relative "mcp/prompt/argument"
-require_relative "mcp/prompt/message"
-require_relative "mcp/prompt/result"
-require_relative "mcp/resource"
-require_relative "mcp/resource/contents"
-require_relative "mcp/resource/embedded"
-require_relative "mcp/resource_template"
-require_relative "mcp/server"
-require_relative "mcp/server_context"
-require_relative "mcp/server/transports/streamable_http_transport"
-require_relative "mcp/server/transports/stdio_transport"
 require_relative "mcp/string_utils"
-require_relative "mcp/tool"
-require_relative "mcp/tool/input_schema"
-require_relative "mcp/tool/output_schema"
-require_relative "mcp/tool/response"
-require_relative "mcp/tool/annotations"
 require_relative "mcp/transport"
 require_relative "mcp/version"
-require_relative "mcp/client"
-require_relative "mcp/client/http"
-require_relative "mcp/client/tool"
 
 module MCP
+  autoload :Annotations, "mcp/annotations"
+  autoload :Client, "mcp/client"
+  autoload :Content, "mcp/content"
+  autoload :Icon, "mcp/icon"
+  autoload :Prompt, "mcp/prompt"
+  autoload :Resource, "mcp/resource"
+  autoload :ResourceTemplate, "mcp/resource_template"
+  autoload :Server, "mcp/server"
+  autoload :Tool, "mcp/tool"
+
   class << self
     def configure
       yield(configuration)

--- a/lib/mcp/client.rb
+++ b/lib/mcp/client.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require_relative "client/http"
+require_relative "client/tool"
+
 module MCP
   class Client
     # Initializes a new MCP::Client instance.

--- a/lib/mcp/prompt.rb
+++ b/lib/mcp/prompt.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+require_relative "prompt/argument"
+require_relative "prompt/message"
+require_relative "prompt/result"
+
 module MCP
   class Prompt
     class << self

--- a/lib/mcp/resource.rb
+++ b/lib/mcp/resource.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require_relative "resource/contents"
+require_relative "resource/embedded"
+
 module MCP
   class Resource
     attr_reader :uri, :name, :title, :description, :icons, :mime_type

--- a/lib/mcp/server.rb
+++ b/lib/mcp/server.rb
@@ -4,6 +4,9 @@ require_relative "../json_rpc_handler"
 require_relative "instrumentation"
 require_relative "methods"
 require_relative "logging_message_notification"
+require_relative "progress"
+require_relative "server_context"
+require_relative "server/transports"
 
 module MCP
   class ToolNotUnique < StandardError

--- a/lib/mcp/server/transports.rb
+++ b/lib/mcp/server/transports.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module MCP
+  class Server
+    module Transports
+      autoload :StdioTransport, "mcp/server/transports/stdio_transport"
+      autoload :StreamableHTTPTransport, "mcp/server/transports/streamable_http_transport"
+    end
+  end
+end

--- a/lib/mcp/server/transports/stdio_transport.rb
+++ b/lib/mcp/server/transports/stdio_transport.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require_relative "../../transport"
 require "json"
+require_relative "../../transport"
 
 module MCP
   class Server

--- a/lib/mcp/server/transports/streamable_http_transport.rb
+++ b/lib/mcp/server/transports/streamable_http_transport.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require_relative "../../transport"
 require "json"
 require "securerandom"
+require_relative "../../transport"
 
 module MCP
   class Server

--- a/lib/mcp/tool.rb
+++ b/lib/mcp/tool.rb
@@ -1,5 +1,10 @@
 # frozen_string_literal: true
 
+require_relative "tool/annotations"
+require_relative "tool/input_schema"
+require_relative "tool/output_schema"
+require_relative "tool/response"
+
 module MCP
   class Tool
     class << self

--- a/test/mcp/instrumentation_test.rb
+++ b/test/mcp/instrumentation_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "mcp/instrumentation"
 
 module MCP
   class InstrumentationTest < ActiveSupport::TestCase

--- a/test/mcp/methods_test.rb
+++ b/test/mcp/methods_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "mcp/methods"
 
 module MCP
   class MethodsTest < ActiveSupport::TestCase


### PR DESCRIPTION
## Motivation and Context

`lib/mcp.rb` currently declares all `require_relative` statements in one place. As a result, Server and Client are both loaded, the stdio and Streamable HTTP transports are both loaded, and Tool, Prompt, and Resource are all loaded, regardless of which components are actually used.

These components are selected by the user depending on their use case, so loading everything upfront is unnecessary.

Using `autoload` for selected constants defers loading until the constant is actually referenced, so only the subsystems required by the user are loaded.

## How Has This Been Tested?

All existing tests pass unchanged.

## Breaking Change

None. This change only defers loading of unused components.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
