### PR TITLE
Remove dead code in `handle_regular_request`

### DIFF
--- a/lib/mcp/server/transports/streamable_http_transport.rb
+++ b/lib/mcp/server/transports/streamable_http_transport.rb
@@ -263,23 +263,16 @@ module MCP
             end
           end
 
-          response = @server.handle_json(body_string) || ""
+          response = @server.handle_json(body_string)
 
           # Stream can be nil since stateless mode doesn't retain streams
           stream = get_session_stream(session_id) if session_id
 
           if stream
             send_response_to_stream(stream, response, session_id)
-          elsif response.nil? && notification_request?(body_string)
-            [202, { "Content-Type" => "application/json" }, [response]]
           else
             [200, { "Content-Type" => "application/json" }, [response]]
           end
-        end
-
-        def notification_request?(body_string)
-          body = parse_request_body(body_string)
-          body.is_a?(Hash) && body["method"].start_with?("notifications/")
         end
 
         def get_session_stream(session_id)


### PR DESCRIPTION
## Motivation and Context

Notifications never reach `handle_regular_request` because `handle_post` checks `notification?(body)` first and returns 202 via `handle_accepted`. Since only notifications cause `handle_json` to return `nil`, `response` is always non-`nil` here.

## How Has This Been Tested?

All existing tests pass unchanged.

## Breaking Changes

None.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

