### PR TITLE
Use mutex-protected `session_exists?` in `handle_regular_request`

### DIFF
--- a/lib/mcp/server/transports/streamable_http_transport.rb
+++ b/lib/mcp/server/transports/streamable_http_transport.rb
@@ -259,8 +259,7 @@ module MCP
 
         def handle_regular_request(body_string, session_id)
           unless @stateless
-            # If session ID is provided, but not in the sessions hash, return an error
-            if session_id && !@sessions.key?(session_id)
+            if session_id && !session_exists?(session_id)
               return session_not_found_response
             end
           end

--- a/test/mcp/server/transports/streamable_http_transport_test.rb
+++ b/test/mcp/server/transports/streamable_http_transport_test.rb
@@ -1222,6 +1222,31 @@ module MCP
           assert_equal([], response[2])
         end
 
+        test "handle_regular_request checks session existence under mutex" do
+          init_request = create_rack_request(
+            "POST",
+            "/",
+            { "CONTENT_TYPE" => "application/json" },
+            { jsonrpc: "2.0", method: "initialize", id: "init" }.to_json,
+          )
+          init_response = @transport.handle_request(init_request)
+          session_id = init_response[1]["Mcp-Session-Id"]
+
+          @transport.expects(:session_exists?).with(session_id).returns(true)
+
+          request = create_rack_request(
+            "POST",
+            "/",
+            {
+              "CONTENT_TYPE" => "application/json",
+              "HTTP_MCP_SESSION_ID" => session_id,
+            },
+            { jsonrpc: "2.0", method: "ping", id: "456" }.to_json,
+          )
+          response = @transport.handle_request(request)
+          assert_equal(200, response[0])
+        end
+
         private
 
         def create_rack_request(method, path, headers, body = nil)


### PR DESCRIPTION
## Motivation and Context

`handle_regular_request` was checking `@sessions.key?(session_id)` directly without holding `@mutex`, while concurrent threads could modify `@sessions` via `cleanup_session` or `handle_delete`. This created a TOCTOU race where the check could pass but the session could be deleted before subsequent use.

The class already provides a mutex-protected `session_exists?` helper, and `handle_get` already uses it. This change makes `handle_regular_request` consistent with `handle_get`.

## How Has This Been Tested?

Added a test that verifies `handle_regular_request` delegates to the mutex-protected `session_exists?` helper instead of accessing `@sessions` directly.

All existing tests pass.

## Breaking Change

None.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
