### PR TITLE
Use `missing_session_id_response` method in `handle_delete`

### DIFF
--- a/lib/mcp/server/transports/streamable_http_transport.rb
+++ b/lib/mcp/server/transports/streamable_http_transport.rb
@@ -154,13 +154,7 @@ module MCP
             return success_response
           end
 
-          session_id = request.env["HTTP_MCP_SESSION_ID"]
-
-          return [
-            400,
-            { "Content-Type" => "application/json" },
-            [{ error: "Missing session ID" }.to_json],
-          ] unless session_id
+          return missing_session_id_response unless (session_id = request.env["HTTP_MCP_SESSION_ID"])
 
           cleanup_session(session_id)
           success_response


### PR DESCRIPTION
## Motivation and Context

`handle_delete` had an inline error response for "Missing session ID" that was identical to the existing `missing_session_id_response` helper method. `handle_get` already uses this helper for the same purpose.

## How Has This Been Tested?

All existing tests pass. The behavior is unchanged.

## Breaking Change

None.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
