### PR TITLE
Release 0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.1] - 2026-03-23
+
+### Added
+
+- Allow `Client#call_tool` to accept a tool name (#266)
+
+### Fixed
+
+- Return 404 for invalid session ID in `handle_delete` (#261)
+
 ## [0.9.0] - 2026-03-20
 
 ### Added

--- a/lib/mcp/version.rb
+++ b/lib/mcp/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MCP
-  VERSION = "0.9.0"
+  VERSION = "0.9.1"
 end


### PR DESCRIPTION
@modelcontextprotocol/ruby-sdk 

This release includes a bug fix that did not make it into v0.9.0. It also simplifies the example in https://github.com/modelcontextprotocol/quickstart-resources/pull/121.

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
