### PR TITLE
Use accessor method in `server_context_with_meta` instead of ivar

### DIFF
--- a/lib/mcp/server.rb
+++ b/lib/mcp/server.rb
@@ -531,14 +531,14 @@ module MCP
 
     def server_context_with_meta(request)
       meta = request[:_meta]
-      if meta && @server_context.is_a?(Hash)
-        context = @server_context.dup
+      if meta && server_context.is_a?(Hash)
+        context = server_context.dup
         context[:_meta] = meta
         context
-      elsif meta && @server_context.nil?
+      elsif meta && server_context.nil?
         { _meta: meta }
       else
-        @server_context
+        server_context
       end
     end
   end

--- a/test/mcp/server_test.rb
+++ b/test/mcp/server_test.rb
@@ -1731,5 +1731,31 @@ module MCP
         end
       end
     end
+
+    test "server_context_with_meta uses accessor method, not ivar directly" do
+      subclass = Class.new(Server) do
+        def server_context
+          { custom: "from_accessor" }
+        end
+      end
+
+      server = subclass.new(name: "test", tools: [])
+
+      received_context = nil
+      server.define_tool(name: "ctx_tool") do |server_context:|
+        received_context = server_context
+        Tool::Response.new([{ type: "text", text: "ok" }])
+      end
+
+      request = {
+        jsonrpc: "2.0",
+        method: "tools/call",
+        id: 1,
+        params: { name: "ctx_tool", arguments: {} },
+      }
+
+      server.handle(request)
+      assert_equal "from_accessor", received_context[:custom]
+    end
   end
 end


### PR DESCRIPTION
## Motivation and Context

`server_context_with_meta` reads `@server_context` (the instance variable) directly instead of calling the `server_context` accessor method. This prevents subclasses from overriding `server_context`. Ffor example, to provide thread-local context in multi-threaded servers like Puma.

Fixes #271.

## How Has This Been Tested?

Added a regression test and passed.

## Breaking Changes

None. This restores the expected behavior of `attr_accessor :server_context`.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
