### PR TITLE
Release 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-03-30
+
+### Added
+
+- Session expiry controls for `StreamableHTTPTransport` via `session_idle_timeout:` option (#268)
+
+### Changed
+
+- `ServerSession` for per-connection state (#275)
+
+### Removed
+
+- Remove `Server#notify_progress` broadcast API (#276)
+- Remove undocumented handler override methods (#270)
+
+### Fixed
+
+- Reject POST requests without session ID in stateful mode (#274)
+
 ## [0.9.2] - 2026-03-27
 
 ### Fixed

--- a/lib/mcp/version.rb
+++ b/lib/mcp/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MCP
-  VERSION = "0.9.2"
+  VERSION = "0.10.0"
 end


### PR DESCRIPTION
@modelcontextprotocol/ruby-sdk This release focuses primarily on changes related to the internal session architecture. It also removes some publicly exposed methods that are effectively obsolete.

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
