### PR TITLE
[Doc] Add CNAME file to preserve custom domain across deployments

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+ruby.sdk.modelcontextprotocol.io


### PR DESCRIPTION
## Motivation and Context

Accessing https://ruby.sdk.modelcontextprotocol.io/ is expected to show the content of https://modelcontextprotocol.github.io/ruby-sdk/, but it currently does not. This change fixes that issue.

The `generate-gh-pages.sh` script cleans all files from the gh-pages branch root before copying from `docs/`. This removes the CNAME file that GitHub Pages uses for the custom domain, causing `ruby.sdk.modelcontextprotocol.io` to break on every release.
https://github.com/modelcontextprotocol/ruby-sdk/blob/v0.10.0/bin/generate-gh-pages.sh#L91-L93

By placing the CNAME file in `docs/`, it will be automatically copied to `gh-pages` during each deployment. https://github.com/modelcontextprotocol/ruby-sdk/blob/v0.10.0/bin/generate-gh-pages.sh#L95-L97

The following is a PR related to the configuration of ruby.sdk.modelcontextprotocol.io.

- https://github.com/modelcontextprotocol/ruby-sdk/pull/181
- https://github.com/modelcontextprotocol/dns/pull/14
- https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2486

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
