### PR TITLE
Use `symbolize_names: true` in `JSON.parse` calls

### DIFF
--- a/lib/mcp/server/transports/streamable_http_transport.rb
+++ b/lib/mcp/server/transports/streamable_http_transport.rb
@@ -176,7 +176,7 @@ module MCP
           body = parse_request_body(body_string)
           return body unless body.is_a?(Hash) # Error response
 
-          if body["method"] == "initialize"
+          if body[:method] == "initialize"
             handle_initialization(body_string, body)
           else
             return missing_session_id_response if !@stateless && !session_id
@@ -277,17 +277,17 @@ module MCP
         end
 
         def parse_request_body(body_string)
-          JSON.parse(body_string)
+          JSON.parse(body_string, symbolize_names: true)
         rescue JSON::ParserError, TypeError
           [400, { "Content-Type" => "application/json" }, [{ error: "Invalid JSON" }.to_json]]
         end
 
         def notification?(body)
-          !body["id"] && !!body["method"]
+          !body[:id] && !!body[:method]
         end
 
         def response?(body)
-          !!body["id"] && !body["method"]
+          !!body[:id] && !body[:method]
         end
 
         def handle_initialization(body_string, body)

--- a/lib/mcp/tool/schema.rb
+++ b/lib/mcp/tool/schema.rb
@@ -8,7 +8,7 @@ module MCP
       attr_reader :schema
 
       def initialize(schema = {})
-        @schema = deep_transform_keys(JSON.parse(JSON.dump(schema)), &:to_sym)
+        @schema = JSON.parse(JSON.dump(schema), symbolize_names: true)
         @schema[:type] ||= "object"
         validate_schema!
       end
@@ -25,19 +25,6 @@ module MCP
 
       def fully_validate(data)
         JSON::Validator.fully_validate(to_h, data)
-      end
-
-      def deep_transform_keys(schema, &block)
-        case schema
-        when Hash
-          schema.each_with_object({}) do |(key, value), result|
-            result[yield(key)] = deep_transform_keys(value, &block)
-          end
-        when Array
-          schema.map { |e| deep_transform_keys(e, &block) }
-        else
-          schema
-        end
       end
 
       def validate_schema!


### PR DESCRIPTION
## Motivation and Context

Replace custom `deep_transform_keys` in `Tool::Schema` and string key access in `StreamableHTTPTransport` with the `symbolize_names: true` option of `JSON.parse`.

This aligns `StreamableHTTPTransport` with `StdioTransport`, which already uses `symbolize_names: true`.

## How Has This Been Tested?

This is a refactoring that preserves the existing tests.

## Breaking Changes

None.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
