### PR TITLE
Use `rescue StandardError` for stream close

### DIFF
--- a/lib/mcp/server/transports/streamable_http_transport.rb
+++ b/lib/mcp/server/transports/streamable_http_transport.rb
@@ -150,8 +150,8 @@ module MCP
             # removed from `@sessions` above, so other threads will not find them
             # and will not attempt to close the same stream.
             stream.close
-          rescue
-            nil
+          rescue StandardError
+            # Ignore close-related errors from already closed/broken streams.
           end
         end
 
@@ -239,8 +239,8 @@ module MCP
 
           begin
             session[:stream]&.close
-          rescue
-            nil
+          rescue StandardError
+            # Ignore close-related errors from already closed/broken streams.
           end
           @sessions.delete(session_id)
         end


### PR DESCRIPTION
## Motivation and Context

Replace bare `rescue` with explicit `rescue StandardError` in stream cleanup to clarify intent, with a comment explaining why. In Ruby, `rescue` without an exception class is equivalent to `rescue StandardError`, so this is a readability improvement with no behavior change.

## How Has This Been Tested?

Existing tests will pass.

## Breaking Changes

This is a readability improvement with no behavior change.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
