### PR TITLE
Add `extra_rdoc_files` to gemspec

### DIFF
--- a/mcp.gemspec
+++ b/mcp.gemspec
@@ -23,7 +23,8 @@ Gem::Specification.new do |spec|
   spec.metadata["bug_tracker_uri"] = "#{spec.homepage}/issues"
   spec.metadata["documentation_uri"] = "https://rubydoc.info/gems/mcp"
 
-  spec.files = Dir["LICENSE", "README.md", "lib/**/*"]
+  spec.files = Dir["lib/**/*"]
+  spec.extra_rdoc_files = ["LICENSE", "README.md"]
 
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }


### PR DESCRIPTION
## Motivation and Context

This makes `LICENSE` and `README.md` available to RDoc documentation. The files remain included in the gem package because `Gem::Specification#files` automatically merges `extra_rdoc_files`.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
