### PR TITLE
[Doc] Clarify that `StreamableHTTPTransport` requires a single-process server

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,13 @@ transport = MCP::Server::Transports::StreamableHTTPTransport.new(server, session
 
 ### Usage
 
+> [!IMPORTANT]
+> `MCP::Server::Transports::StreamableHTTPTransport` stores session and SSE stream state in memory,
+> so it must run in a single process. Use a single-process server (e.g., Puma with `workers 0`).
+> Multi-process configurations (Unicorn, or Puma with `workers > 0`) fork separate processes that
+> do not share memory, which breaks session management and SSE connections.
+> Stateless mode (`stateless: true`) does not use sessions and works with any server configuration.
+
 #### Rails Controller
 
 When added to a Rails controller on a route that handles POST requests, your server will be compliant with non-streaming


### PR DESCRIPTION
## Motivation and Context

`StreamableHTTPTransport` stores session and SSE stream state in memory using instance variables (`@sessions`, `@mutex`). This design requires all HTTP requests to be handled within the same process to share state.

Process-based servers like Unicorn fork separate worker processes that do not share memory, which breaks session management and SSE connections. This requirement is not obvious from the current documentation.

## How Has This Been Tested?

Documentation-only change.

## Breaking Changes

None.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
