### PR TITLE
[Doc] Note sticky session requirement for multi-instance deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,11 @@ end
 > so it must run in a single process. Use a single-process server (e.g., Puma with `workers 0`).
 > Multi-process configurations (Unicorn, or Puma with `workers > 0`) fork separate processes that
 > do not share memory, which breaks session management and SSE connections.
+>
+> When running multiple server instances behind a load balancer, configure your load balancer to use
+> sticky sessions (session affinity) so that requests with the same `Mcp-Session-Id` header are always
+> routed to the same instance.
+>
 > Stateless mode (`stateless: true`) does not use sessions and works with any server configuration.
 
 ### Configuration


### PR DESCRIPTION
## Motivation and Context

PR #290 documented that `StreamableHTTPTransport` requires a single-process server. However, when running multiple server instances behind a load balancer, requests for the same session must be routed to the same instance since session state is stored in memory.

This adds a note about using sticky sessions (session affinity) based on the `Mcp-Session-Id` header.

## How Has This Been Tested?

Documentation-only change.

## Breaking Changes

None.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
