### PR TITLE
Fix missing output_schema argument in 'define_tool' API

### DIFF
--- a/lib/mcp/server.rb
+++ b/lib/mcp/server.rb
@@ -145,8 +145,8 @@ module MCP
       end
     end
 
-    def define_tool(name: nil, title: nil, description: nil, input_schema: nil, annotations: nil, meta: nil, &block)
-      tool = Tool.define(name: name, title: title, description: description, input_schema: input_schema, annotations: annotations, meta: meta, &block)
+    def define_tool(name: nil, title: nil, description: nil, input_schema: nil, output_schema: nil, annotations: nil, meta: nil, &block)
+      tool = Tool.define(name: name, title: title, description: description, input_schema: input_schema, output_schema: output_schema, annotations: annotations, meta: meta, &block)
       tool_name = tool.name_value
 
       @tool_names << tool_name

--- a/test/mcp/server_test.rb
+++ b/test/mcp/server_test.rb
@@ -1127,10 +1127,15 @@ module MCP
         name: "defined_tool",
         description: "Defined tool",
         input_schema: { type: "object", properties: { message: { type: "string" } }, required: ["message"] },
+        output_schema: { type: "object", properties: { response: { type: "string" } }, required: ["response"] },
         meta: { foo: "bar" },
       ) do |message:|
-        Tool::Response.new(message)
+        Tool::Response.new({ "response" => message })
       end
+
+      stored_tool = @server.instance_variable_get(:@tools)["defined_tool"]
+      assert_not_nil(stored_tool)
+      assert_equal(MCP::Tool::OutputSchema.new({ type: "object", properties: { response: { type: "string" } }, required: ["response"] }), stored_tool.output_schema)
 
       response = @server.handle({
         jsonrpc: "2.0",
@@ -1139,7 +1144,7 @@ module MCP
         id: 1,
       })
 
-      assert_equal({ content: "success", isError: false }, response[:result])
+      assert_equal({ content: { "response" => "success" }, isError: false }, response[:result])
     end
 
     test "#define_tool adds a tool with duplicated tool name to the server" do


### PR DESCRIPTION
Add missing `output_schema` keyword argument to `MCP::Server#define_tool`

## Motivation and Context
Using the `define_tool` API it's not currently possible to pass in the `output_schema` value.

## How Has This Been Tested?
Unit tested

## Breaking Changes
N/A

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
N/A
