### PR TITLE
Validate Content-Type on POST requests

### DIFF
--- a/lib/mcp/server/transports/streamable_http_transport.rb
+++ b/lib/mcp/server/transports/streamable_http_transport.rb
@@ -267,6 +267,9 @@ module MCP
           accept_error = validate_accept_header(request, REQUIRED_POST_ACCEPT_TYPES)
           return accept_error if accept_error
 
+          content_type_error = validate_content_type(request)
+          return content_type_error if content_type_error
+
           body_string = request.body.read
           session_id = extract_session_id(request)
 
@@ -397,6 +400,18 @@ module MCP
           header.split(",").map do |part|
             part.split(";").first.strip
           end
+        end
+
+        def validate_content_type(request)
+          content_type = request.env["CONTENT_TYPE"]
+          media_type = content_type&.split(";")&.first&.strip&.downcase
+          return if media_type == "application/json"
+
+          [
+            415,
+            { "Content-Type" => "application/json" },
+            [{ error: "Unsupported Media Type: Content-Type must be application/json" }.to_json],
+          ]
         end
 
         def not_acceptable_response(required_types)

--- a/test/mcp/server/transports/streamable_http_transport_test.rb
+++ b/test/mcp/server/transports/streamable_http_transport_test.rb
@@ -1143,6 +1143,51 @@ module MCP
           assert_equal "Method not allowed", body["error"]
         end
 
+        test "POST request without Content-Type returns 415" do
+          request = create_rack_request_without_accept(
+            "POST",
+            "/",
+            { "HTTP_ACCEPT" => "application/json, text/event-stream" },
+            { jsonrpc: "2.0", method: "initialize", id: "123" }.to_json,
+          )
+
+          response = @transport.handle_request(request)
+          assert_equal 415, response[0]
+
+          body = JSON.parse(response[2][0])
+          assert_equal "Unsupported Media Type: Content-Type must be application/json", body["error"]
+        end
+
+        test "POST request with wrong Content-Type returns 415" do
+          request = create_rack_request_without_accept(
+            "POST",
+            "/",
+            {
+              "CONTENT_TYPE" => "text/plain",
+              "HTTP_ACCEPT" => "application/json, text/event-stream",
+            },
+            { jsonrpc: "2.0", method: "initialize", id: "123" }.to_json,
+          )
+
+          response = @transport.handle_request(request)
+          assert_equal 415, response[0]
+        end
+
+        test "POST request with Content-Type including charset succeeds" do
+          request = create_rack_request_without_accept(
+            "POST",
+            "/",
+            {
+              "CONTENT_TYPE" => "application/json; charset=utf-8",
+              "HTTP_ACCEPT" => "application/json, text/event-stream",
+            },
+            { jsonrpc: "2.0", method: "initialize", id: "123" }.to_json,
+          )
+
+          response = @transport.handle_request(request)
+          assert_equal 200, response[0]
+        end
+
         test "POST request without Accept header returns 406" do
           request = create_rack_request_without_accept(
             "POST",


### PR DESCRIPTION
## Motivation and Context

The MCP Streamable HTTP specification requires POST request bodies to be JSON-RPC messages with `Content-Type: application/json`. The Ruby SDK did not validate Content-Type, accepting requests with any or no Content-Type. The Python SDK validates this and returns 415 Unsupported Media Type for non-JSON Content-Types.

## How Has This Been Tested?

Added tests for Content-Type validation:

- POST without Content-Type returns 415
- POST with `Content-Type: text/plain` returns 415
- POST with `Content-Type: application/json; charset=utf-8` succeeds

## Breaking Changes

POST requests without `Content-Type: application/json` now return 415 Unsupported Media Type. This is a spec compliance fix.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
