### PR TITLE
Release 0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.0] - 2026-04-16
+
+### Added
+
+- Make `StreamableHTTPTransport` a Rack application (#263)
+- Support `elicitation/create` per MCP specification (#312)
+- Add `around_request` hook for request instrumentation (#309)
+- Add `_meta` field to resource, content, and result classes (#310)
+
+### Removed
+
+- Remove `Server#create_sampling_message` direct call (#311)
+
 ## [0.12.0] - 2026-04-11
 
 ### Added

--- a/lib/mcp/version.rb
+++ b/lib/mcp/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MCP
-  VERSION = "0.12.0"
+  VERSION = "0.13.0"
 end


### PR DESCRIPTION
@modelcontextprotocol/ruby-sdk New features and changes have landed, making it a good time to cut a release. Further feature proposals can be incorporated in future releases.

In particular, releasing "Make `StreamableHTTPTransport` a Rack application" soon would help keep it consistent with the README.md for Rails integration.

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

