### PR TITLE
Update homepage URL in gemspec

### DIFF
--- a/mcp.gemspec
+++ b/mcp.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
 
   spec.summary       = "The official Ruby SDK for Model Context Protocol servers and clients"
   spec.description   = spec.summary
-  spec.homepage      = "https://github.com/modelcontextprotocol/ruby-sdk"
+  spec.homepage      = "https://ruby.sdk.modelcontextprotocol.io"
   spec.license       = "Apache-2.0"
 
   # Since this library is used by a broad range of users, it does not align its support policy with Ruby's EOL.
@@ -19,8 +19,8 @@ Gem::Specification.new do |spec|
   spec.metadata["allowed_push_host"] = "https://rubygems.org"
   spec.metadata["changelog_uri"] = "https://github.com/modelcontextprotocol/ruby-sdk/releases/tag/v#{spec.version}"
   spec.metadata["homepage_uri"] = spec.homepage
-  spec.metadata["source_code_uri"] = spec.homepage
-  spec.metadata["bug_tracker_uri"] = "#{spec.homepage}/issues"
+  spec.metadata["source_code_uri"] = "https://github.com/modelcontextprotocol/ruby-sdk"
+  spec.metadata["bug_tracker_uri"] = "#{spec.metadata["source_code_uri"]}/issues"
   spec.metadata["documentation_uri"] = "https://rubydoc.info/gems/mcp"
 
   spec.files = Dir["lib/**/*"]


### PR DESCRIPTION
## Motivation and Context

Follow-up to https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2486 and #317.

This PR updates the homepage URL to https://ruby.sdk.modelcontextprotocol.io and makes it consistent with the link on the SDK page:
https://modelcontextprotocol.io/docs/sdk

Along with this update, the Website URL in the repository sidebar will be updated from https://rubygems.org/gems/mcp to https://ruby.sdk.modelcontextprotocol.io.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
