### PR TITLE
[Doc] Fix a typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1051,7 +1051,7 @@ This class supports:
 - Tool invocation via the `tools/call` method (`MCP::Client#call_tools`)
 - Resource listing via the `resources/list` method (`MCP::Client#resources`)
 - Resource template listing via the `resources/templates/list` method (`MCP::Client#resource_templates`)
-- Resource reading via the `resources/read` method (`MCP::Client#read_resources`)
+- Resource reading via the `resources/read` method (`MCP::Client#read_resource`)
 - Prompt listing via the `prompts/list` method (`MCP::Client#prompts`)
 - Prompt retrieval via the `prompts/get` method (`MCP::Client#get_prompt`)
 - Automatic JSON-RPC 2.0 message formatting


### PR DESCRIPTION
The method name in the client feature list was `MCP::Client#read_resources` (plural), but the actual method is `MCP::Client#read_resource` (singular).

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
