### PR TITLE
Remove useless condition in example

### DIFF
--- a/examples/http_client.rb
+++ b/examples/http_client.rb
@@ -137,8 +137,7 @@ class MCPHTTPClient
   end
 end
 
-# Main script
-if __FILE__ == $PROGRAM_NAME
+def main
   puts <<~MESSAGE
     MCP HTTP Client Example
     Make sure the HTTP server is running (ruby examples/http_server.rb)
@@ -182,3 +181,5 @@ if __FILE__ == $PROGRAM_NAME
     client.close_session
   end
 end
+
+main

--- a/examples/streamable_http_client.rb
+++ b/examples/streamable_http_client.rb
@@ -176,4 +176,4 @@ def main
   end
 end
 
-main if __FILE__ == $PROGRAM_NAME
+main


### PR DESCRIPTION
## Motivation and Context

The example files `examples/http_client.rb` and `examples/streamable_http_client.rb` are intended to be run as standalone scripts and are not designed to be reused as modules (e.g., via `require`). The `if __FILE__ == $PROGRAM_NAME` guard therefore serves no purpose and is removed.

## How Has This Been Tested?

Manually verified that each example script can still be executed directly (`ruby examples/http_client.rb`, `ruby examples/streamable_http_client.rb`). No automated tests cover files under `examples/`.

## Breaking Changes

None. The files under `examples/` are standalone scripts and are not part of the gem's public API.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
