### PR TITLE
Use `Server#tools` instead of `instance_variable_get`

### DIFF
--- a/test/mcp/server_test.rb
+++ b/test/mcp/server_test.rb
@@ -1390,7 +1390,7 @@ module MCP
         Tool::Response.new({ "response" => message })
       end
 
-      stored_tool = @server.instance_variable_get(:@tools)["defined_tool"]
+      stored_tool = @server.tools["defined_tool"]
       assert_not_nil(stored_tool)
       assert_equal(MCP::Tool::OutputSchema.new({ type: "object", properties: { response: { type: "string" } }, required: ["response"] }), stored_tool.output_schema)
 


### PR DESCRIPTION
Follow-up to https://github.com/modelcontextprotocol/ruby-sdk/pull/301#discussion_r3046699277.

`Server#tools` method can be used instead of a hack like `instance_variable_get(:@tools)`.

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
