### PR TITLE
fix: preserve client tool output schemas

### DIFF
--- a/lib/mcp/client.rb
+++ b/lib/mcp/client.rb
@@ -123,6 +123,7 @@ module MCP
           name: tool["name"],
           description: tool["description"],
           input_schema: tool["inputSchema"],
+          output_schema: tool["outputSchema"],
         )
       end
 

--- a/test/mcp/client_test.rb
+++ b/test/mcp/client_test.rb
@@ -81,7 +81,12 @@ module MCP
       mock_response = {
         "result" => {
           "tools" => [
-            { "name" => "tool1", "description" => "tool1", "inputSchema" => {} },
+            {
+              "name" => "tool1",
+              "description" => "tool1",
+              "inputSchema" => {},
+              "outputSchema" => { "type" => "object", "properties" => { "result" => { "type" => "string" } } },
+            },
             { "name" => "tool2", "description" => "tool2", "inputSchema" => {} },
           ],
         },
@@ -97,7 +102,9 @@ module MCP
 
       assert_equal(2, tools.size)
       assert_equal("tool1", tools.first.name)
+      assert_equal({ "type" => "object", "properties" => { "result" => { "type" => "string" } } }, tools.first.output_schema)
       assert_equal("tool2", tools.last.name)
+      assert_nil(tools.last.output_schema)
     end
 
     def test_tools_returns_empty_array_when_no_tools


### PR DESCRIPTION
## Summary
- Preserve `outputSchema` from `tools/list` responses when constructing `MCP::Client::Tool` objects
- Cover advertised and absent output schemas in client tool discovery tests

## Why
The MCP tool definition includes optional `outputSchema` metadata for the structure of `structuredContent` returned by `tools/call`. Clients need this schema to validate structured tool results and to build typed integrations from discovered tool metadata.

## Tests
- `dev test test TEST=test/mcp/client_test.rb`
- `dev test test TEST=test/mcp/client/tool_test.rb`
- `git diff --check`