### PR TITLE
refactor: share tool schema validation helpers

### DIFF
--- a/lib/mcp/tool.rb
+++ b/lib/mcp/tool.rb
@@ -93,22 +93,29 @@ module MCP
       def input_schema(value = NOT_SET)
         if value == NOT_SET
           input_schema_value
-        elsif value.is_a?(Hash)
-          @input_schema_value = InputSchema.new(value)
-        elsif value.is_a?(InputSchema)
-          @input_schema_value = value
+        elsif (schema = coerce_schema(value, InputSchema))
+          @input_schema_value = schema
         end
       end
 
       def output_schema(value = NOT_SET)
         if value == NOT_SET
           output_schema_value
-        elsif value.is_a?(Hash)
-          @output_schema_value = OutputSchema.new(value)
-        elsif value.is_a?(OutputSchema)
-          @output_schema_value = value
+        elsif (schema = coerce_schema(value, OutputSchema))
+          @output_schema_value = schema
         end
       end
+
+      def coerce_schema(value, schema_class)
+        case value
+        when Hash
+          schema_class.new(value)
+        when schema_class
+          value
+        end
+      end
+
+      private :coerce_schema
 
       def meta(value = NOT_SET)
         if value == NOT_SET

--- a/lib/mcp/tool/input_schema.rb
+++ b/lib/mcp/tool/input_schema.rb
@@ -18,10 +18,7 @@ module MCP
       end
 
       def validate_arguments(arguments)
-        errors = fully_validate(arguments)
-        if errors.any?
-          raise ValidationError, "Invalid arguments: #{errors.join(", ")}"
-        end
+        fully_validate!(arguments, "arguments")
       end
     end
   end

--- a/lib/mcp/tool/output_schema.rb
+++ b/lib/mcp/tool/output_schema.rb
@@ -8,10 +8,7 @@ module MCP
       class ValidationError < StandardError; end
 
       def validate_result(result)
-        errors = fully_validate(result)
-        if errors.any?
-          raise ValidationError, "Invalid result: #{errors.join(", ")}"
-        end
+        fully_validate!(result, "result")
       end
     end
   end

--- a/lib/mcp/tool/schema.rb
+++ b/lib/mcp/tool/schema.rb
@@ -31,8 +31,11 @@ module MCP
 
       private
 
-      def fully_validate(data)
-        JSON::Validator.fully_validate(schema_for_validation, data)
+      def fully_validate!(payload, label)
+        errors = JSON::Validator.fully_validate(schema_for_validation, payload)
+        if errors.any?
+          raise self.class::ValidationError, "Invalid #{label}: #{errors.join(", ")}"
+        end
       end
 
       def validate_schema!


### PR DESCRIPTION
## Summary
- Move the shared JSON Schema data-validation flow into `MCP::Tool::Schema`
- Keep `InputSchema#validate_arguments` and `OutputSchema#validate_result` as thin public wrappers with unchanged error messages
- Share schema coercion between the `input_schema` and `output_schema` setters

## Tests
- `dev test test TEST=test/mcp/tool/input_schema_test.rb`
- `dev test test TEST=test/mcp/tool/output_schema_test.rb`
- `dev test test TEST=test/mcp/tool_test.rb`
- `dev test test TEST=test/mcp/server_test.rb`
- `dev test test TEST=test/mcp/configuration_test.rb`
- `dev test`
- `bundle exec rubocop lib/mcp/tool.rb lib/mcp/tool/schema.rb lib/mcp/tool/input_schema.rb lib/mcp/tool/output_schema.rb`
- `git diff --check`