### PR TITLE
Refactor `handle_delete` to use `extract_session_id`

### DIFF
--- a/lib/mcp/server/transports/streamable_http_transport.rb
+++ b/lib/mcp/server/transports/streamable_http_transport.rb
@@ -426,7 +426,7 @@ module MCP
             return success_response
           end
 
-          return missing_session_id_response unless (session_id = request.env["HTTP_MCP_SESSION_ID"])
+          return missing_session_id_response unless (session_id = extract_session_id(request))
           return session_not_found_response unless session_exists?(session_id)
 
           protocol_version_error = validate_protocol_version_header(request)


### PR DESCRIPTION
## Motivation and Context

`handle_post` and `handle_get` already use this helper, but `handle_delete` inlined `request.env["HTTP_MCP_SESSION_ID"]`. This aligns all three handlers consistently.

## How Has This Been Tested?

It has passed existing tests.

## Breaking Changes

None.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
