### PR TITLE
Fix case-sensitive Accept header comparison

### DIFF
--- a/lib/mcp/server/transports/streamable_http_transport.rb
+++ b/lib/mcp/server/transports/streamable_http_transport.rb
@@ -504,7 +504,7 @@ module MCP
 
         def parse_accept_header(header)
           header.split(",").map do |part|
-            part.split(";").first.strip
+            part.split(";").first.strip.downcase
           end
         end
 

--- a/test/mcp/server/transports/streamable_http_transport_test.rb
+++ b/test/mcp/server/transports/streamable_http_transport_test.rb
@@ -1465,6 +1465,45 @@ module MCP
           assert_equal 200, response[0]
         end
 
+        test "POST request with mixed-case Accept header succeeds" do
+          request = create_rack_request_without_accept(
+            "POST",
+            "/",
+            {
+              "CONTENT_TYPE" => "application/json",
+              "HTTP_ACCEPT" => "Application/JSON, Text/Event-Stream",
+            },
+            { jsonrpc: "2.0", method: "initialize", id: "123" }.to_json,
+          )
+
+          response = @transport.handle_request(request)
+          assert_equal 200, response[0]
+        end
+
+        test "GET request with upper-case Accept header succeeds" do
+          init_request = create_rack_request(
+            "POST",
+            "/",
+            { "CONTENT_TYPE" => "application/json" },
+            { jsonrpc: "2.0", method: "initialize", id: "123" }.to_json,
+          )
+          init_response = @transport.handle_request(init_request)
+          session_id = init_response[1]["Mcp-Session-Id"]
+
+          request = create_rack_request_without_accept(
+            "GET",
+            "/",
+            {
+              "HTTP_ACCEPT" => "TEXT/EVENT-STREAM",
+              "HTTP_MCP_SESSION_ID" => session_id,
+            },
+          )
+
+          response = @transport.handle_request(request)
+          assert_equal 200, response[0]
+          assert_equal "text/event-stream", response[1]["Content-Type"]
+        end
+
         test "GET request without Accept header returns 406" do
           init_request = create_rack_request(
             "POST",


### PR DESCRIPTION
## Motivation and Context

RFC 9110 defines media type comparison as case-insensitive, but `parse_accept_header` compared types without normalizing case. This caused `Application/JSON` or `TEXT/Event-Stream` to be rejected with 406 Not Acceptable.

## How Has This Been Tested?

Added tests for mixed-case Accept headers:

- `Accept: Application/JSON, Text/Event-Stream` succeeds for POST
- `Accept: TEXT/EVENT-STREAM` succeeds for GET SSE

## Breaking Changes

None. This is a bug fix bringing behavior into conformance with RFC 9110.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
