### PR TITLE
[Doc] Fix typos in MCP::Client method references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1755,7 +1755,7 @@ This class supports:
 
 - Liveness check via the `ping` method (`MCP::Client#ping`)
 - Tool listing via the `tools/list` method (`MCP::Client#tools`)
-- Tool invocation via the `tools/call` method (`MCP::Client#call_tools`)
+- Tool invocation via the `tools/call` method (`MCP::Client#call_tool`)
 - Resource listing via the `resources/list` method (`MCP::Client#resources`)
 - Resource template listing via the `resources/templates/list` method (`MCP::Client#resource_templates`)
 - Resource reading via the `resources/read` method (`MCP::Client#read_resource`)

--- a/docs/building-clients.md
+++ b/docs/building-clients.md
@@ -11,7 +11,7 @@ The `MCP::Client` class provides an interface for interacting with MCP servers.
 **Supported operations:**
 
 - Tool listing (`MCP::Client#tools`) and invocation (`MCP::Client#call_tool`)
-- Resource listing (`MCP::Client#resources`) and reading (`MCP::Client#read_resources`)
+- Resource listing (`MCP::Client#resources`) and reading (`MCP::Client#read_resource`)
 - Resource template listing (`MCP::Client#resource_templates`)
 - Prompt listing (`MCP::Client#prompts`) and retrieval (`MCP::Client#get_prompt`)
 - Completion requests (`MCP::Client#complete`)


### PR DESCRIPTION
The methods are defined as singular `MCP::Client#call_tool` and `MCP::Client#read_resource`, but the documentation listed them as plural.

The `read_resources` reference in `README.md` was previously fixed in #330, but the same typo remains in `docs/building-clients.md`. The `call_tools` reference in `README.md` was newly introduced after that fix.

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed