### PR TITLE
Allow skipping validation for schema

### DIFF
--- a/lib/mcp/tool/schema.rb
+++ b/lib/mcp/tool/schema.rb
@@ -13,10 +13,14 @@ module MCP
 
       attr_reader :schema
 
-      def initialize(schema = {})
-        @schema = JSON.parse(JSON.dump(schema), symbolize_names: true)
-        @schema[:type] ||= "object"
-        validate_schema!
+      def initialize(schema = {}, validate = true)
+        if validate
+          @schema = JSON.parse(JSON.dump(schema), symbolize_names: true)
+          @schema[:type] ||= "object"
+          validate_schema!
+        else
+          @schema = schema
+        end
       end
 
       def ==(other)

--- a/test/mcp/tool/schema_test.rb
+++ b/test/mcp/tool/schema_test.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module MCP
+  class Tool
+    class InputSchemaTest < ActiveSupport::TestCase
+      test "initializes with a schema and validates it by default" do
+        valid_schema = {
+          type: "object",
+          properties: {
+            message: { type: "string" },
+          },
+          required: ["message"],
+        }
+        assert_nothing_raised do
+          InputSchema.new(valid_schema)
+        end
+      end
+
+      test "initializes with a schema and skips validation when validate is false" do
+        assert_nothing_raised do
+          InputSchema.new("invalid", false)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
If you're building dynamic tool schemas - every time you build one it has to be validated as the `Schema` class calls `validate_schema!` in the initializer. This can get slow (taking up to ~100ms) for deeper schemas. 

This PR allows the user of the `Schema` class to build the schema themselves and not pay the performance penalty of `JSON.parse(JSON.dump(schema))` and `validate_schema!`.

## How Has This Been Tested?
Added unit tests.

## Breaking Changes
None.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
An alternative 