### PR TITLE
[Doc] Fix `server_context` description for Exception Reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,10 +423,10 @@ The exception reporter receives two arguments:
 - `exception`: The Ruby exception object that was raised
 - `server_context`: A hash containing contextual information about where the error occurred
 
-The server_context hash includes:
+The `server_context` hash includes:
 
-- For tool calls: `{ tool_name: "name", arguments: { ... } }`
-- For general request handling: `{ request: { ... } }`
+- For request handling failures: `{ request: { ... } }` (the raw JSON-RPC request hash)
+- For notification delivery failures: `{ notification: "tools_list_changed" }` (or the relevant notification name)
 
 When an exception occurs:
 


### PR DESCRIPTION
## Motivation and Context

The README's Exception Reporting section claimed that `server_context` includes `{ tool_name: "name", arguments: { ... } }` for tool calls. This matched the implementation in 0.3.0 through 0.5.0, but the `{ tool_name:, arguments: }` context was removed in 0.5.1 when exception reporting was consolidated into the centralized `{ request: request }` path. The README was never updated to reflect this.

`Server#report_exception` is now only called with `{ request: request }` (from `handle_request`) or `{ notification: "..." }` (from notification delivery rescues), and tool call failures flow through the `{ request: ... }` path after being wrapped in a `RequestHandlerError`.

The stale description misled users into expecting `tool_name` and `arguments` in their exception reporter callbacks.

## How Has This Been Tested?

Documentation-only change. No behavioral modification.

## Breaking Changes

None.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
