### PR TITLE
[Doc] Clarify `server_context` Hash requirement for `_meta` merging

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,11 @@ See the relevant sections below for the arguments they receive.
 
 The MCP protocol supports a special [`_meta` parameter](https://modelcontextprotocol.io/specification/2025-06-18/basic#general-fields) in requests that allows clients to pass request-specific metadata. The server automatically extracts this parameter and makes it available to tools and prompts as a nested field within the `server_context`.
 
+> [!NOTE]
+> `_meta` is only merged when `server_context` is a `Hash` (or `nil`, in which case a new `{ _meta: ... }` hash is synthesized).
+> If you assign a non-`Hash` value to `server_context`, `_meta` is not merged and tools will not see it
+> under `server_context[:_meta]`. Keep `server_context` as a `Hash` if your tools need access to `_meta`.
+
 **Access Pattern:**
 
 When a client includes `_meta` in the request params, it becomes available as `server_context[:_meta]`:


### PR DESCRIPTION
## Motivation and Context

The README documents that request-level `_meta` becomes available to tools and prompts under `server_context[:_meta]`.
However, `Server#server_context_with_meta` only merges `_meta` when `server_context` is a `Hash` (or `nil`, in which case a new `{ _meta: ... }` hash is synthesized). When a non-`Hash` value is assigned to `server_context`, `_meta` is silently dropped and tools will not see it under `server_context[:_meta]`.

This adds a note clarifying that `server_context` must be kept as a `Hash` if tools need access to `_meta`.

## How Has This Been Tested?

Documentation-only change, no behavioral modification.

## Breaking Changes

None.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
