### PR TITLE
Default missing `MCP-Protocol-Version` to 2025-03-26 in StreamableHTTPTransport

### DIFF
--- a/lib/mcp/configuration.rb
+++ b/lib/mcp/configuration.rb
@@ -6,6 +6,7 @@ module MCP
     SUPPORTED_STABLE_PROTOCOL_VERSIONS = [
       LATEST_STABLE_PROTOCOL_VERSION, "2025-06-18", "2025-03-26", "2024-11-05",
     ]
+    DEFAULT_NEGOTIATED_PROTOCOL_VERSION = "2025-03-26"
 
     attr_writer :exception_reporter, :around_request
 

--- a/lib/mcp/server/transports/streamable_http_transport.rb
+++ b/lib/mcp/server/transports/streamable_http_transport.rb
@@ -543,8 +543,7 @@ module MCP
         end
 
         def validate_protocol_version_header(request)
-          header_value = request.env["HTTP_MCP_PROTOCOL_VERSION"]
-          return if header_value.nil?
+          header_value = request.env["HTTP_MCP_PROTOCOL_VERSION"] || MCP::Configuration::DEFAULT_NEGOTIATED_PROTOCOL_VERSION
           return if MCP::Configuration::SUPPORTED_STABLE_PROTOCOL_VERSIONS.include?(header_value)
 
           supported = MCP::Configuration::SUPPORTED_STABLE_PROTOCOL_VERSIONS.join(", ")

--- a/test/mcp/server/transports/streamable_http_transport_test.rb
+++ b/test/mcp/server/transports/streamable_http_transport_test.rb
@@ -1778,6 +1778,50 @@ module MCP
           assert_equal 200, response[0]
         end
 
+        test "missing MCP-Protocol-Version header falls back to default for validation" do
+          MCP::Configuration::SUPPORTED_STABLE_PROTOCOL_VERSIONS.stubs(:include?).returns(false)
+
+          request = Rack::Request.new(
+            "REQUEST_METHOD" => "POST",
+            "PATH_INFO" => "/",
+            "rack.input" => StringIO.new(""),
+          )
+
+          response = @transport.send(:validate_protocol_version_header, request)
+          assert_equal 400, response[0]
+
+          body = JSON.parse(response[2][0])
+          assert_includes body["error"]["message"], MCP::Configuration::DEFAULT_NEGOTIATED_PROTOCOL_VERSION
+        end
+
+        test "POST request with empty MCP-Protocol-Version header returns 400" do
+          init_request = create_rack_request(
+            "POST",
+            "/",
+            { "CONTENT_TYPE" => "application/json" },
+            { jsonrpc: "2.0", method: "initialize", id: "init" }.to_json,
+          )
+          init_response = @transport.handle_request(init_request)
+          session_id = init_response[1]["Mcp-Session-Id"]
+
+          request = create_rack_request(
+            "POST",
+            "/",
+            {
+              "CONTENT_TYPE" => "application/json",
+              "HTTP_MCP_SESSION_ID" => session_id,
+              "HTTP_MCP_PROTOCOL_VERSION" => "",
+            },
+            { jsonrpc: "2.0", method: "tools/list", id: "list" }.to_json,
+          )
+
+          response = @transport.handle_request(request)
+          assert_equal 400, response[0]
+
+          body = JSON.parse(response[2][0])
+          assert_equal JsonRpcHandler::ErrorCode::INVALID_REQUEST, body["error"]["code"]
+        end
+
         test "POST request with array body and unsupported MCP-Protocol-Version returns 400" do
           init_request = create_rack_request(
             "POST",


### PR DESCRIPTION
## Motivation and Context

MCP 2025-11-25 (basic/transports#protocol-version-header) specifies:

> For backwards compatibility, if the server does not receive an
> `MCP-Protocol-Version` header, and has no other way to identify the
> version - for example, by relying on the protocol version negotiated
> during initialization - the server SHOULD assume protocol version `2025-03-26`.

PR #347 satisfied only the MUST requirement (reject invalid/unsupported values with 400). The SHOULD requirement to default a missing header to `2025-03-26` was deferred to this follow-up.

This change brings the Ruby SDK in line with the Python SDK (`src/mcp/server/streamable_http.py`), which falls back to `DEFAULT_NEGOTIATED_VERSION` and then revalidates against the supported list.

## Behavior

A new constant `MCP::Configuration::DEFAULT_NEGOTIATED_PROTOCOL_VERSION` holds `"2025-03-26"`. `validate_protocol_version_header` now substitutes this value when the `MCP-Protocol-Version` header is absent, then runs the same supported-version check. Because `"2025-03-26"` is currently in `SUPPORTED_STABLE_PROTOCOL_VERSIONS`, missing headers continue to pass through as before. Once `"2025-03-26"` is dropped from the supported list in a future change, missing headers will start returning 400 with a message naming the defaulted value.

## How Has This Been Tested?

Existing test `POST request without MCP-Protocol-Version header succeeds` continues to pass (observable behavior unchanged today). Added a focused regression test that stubs the supported-version list to exclude `"2025-03-26"` and verifies that a header-less request is rejected with the defaulted value reported in the error message; this exercises the fallback branch directly.

## Breaking Changes

None today. The fallback is future-proofing: when `"2025-03-26"` is eventually dropped, header-less requests will start returning 400. That is the intended spec-driven behavior.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
