### PR TITLE
Extract `MCP::Client` pagination loop into `fetch_all_pages`

### DIFF
--- a/lib/mcp/client.rb
+++ b/lib/mcp/client.rb
@@ -146,21 +146,7 @@ module MCP
     #   end
     def tools
       # TODO: consider renaming to `list_all_tools`.
-      all_tools = []
-      seen = Set.new
-      cursor = nil
-
-      loop do
-        page = list_tools(cursor: cursor)
-        all_tools.concat(page.tools)
-        next_cursor = page.next_cursor
-        break if next_cursor.nil? || seen.include?(next_cursor)
-
-        seen << next_cursor
-        cursor = next_cursor
-      end
-
-      all_tools
+      fetch_all_pages { |cursor| list_tools(cursor: cursor) }.flat_map(&:tools)
     end
 
     # Returns a single page of resources from the server.
@@ -189,21 +175,7 @@ module MCP
     # @return [Array<Hash>] An array of available resources.
     def resources
       # TODO: consider renaming to `list_all_resources`.
-      all_resources = []
-      seen = Set.new
-      cursor = nil
-
-      loop do
-        page = list_resources(cursor: cursor)
-        all_resources.concat(page.resources)
-        next_cursor = page.next_cursor
-        break if next_cursor.nil? || seen.include?(next_cursor)
-
-        seen << next_cursor
-        cursor = next_cursor
-      end
-
-      all_resources
+      fetch_all_pages { |cursor| list_resources(cursor: cursor) }.flat_map(&:resources)
     end
 
     # Returns a single page of resource templates from the server.
@@ -232,21 +204,7 @@ module MCP
     # @return [Array<Hash>] An array of available resource templates.
     def resource_templates
       # TODO: consider renaming to `list_all_resource_templates`.
-      all_templates = []
-      seen = Set.new
-      cursor = nil
-
-      loop do
-        page = list_resource_templates(cursor: cursor)
-        all_templates.concat(page.resource_templates)
-        next_cursor = page.next_cursor
-        break if next_cursor.nil? || seen.include?(next_cursor)
-
-        seen << next_cursor
-        cursor = next_cursor
-      end
-
-      all_templates
+      fetch_all_pages { |cursor| list_resource_templates(cursor: cursor) }.flat_map(&:resource_templates)
     end
 
     # Returns a single page of prompts from the server.
@@ -275,21 +233,7 @@ module MCP
     # @return [Array<Hash>] An array of available prompts.
     def prompts
       # TODO: consider renaming to `list_all_prompts`.
-      all_prompts = []
-      seen = Set.new
-      cursor = nil
-
-      loop do
-        page = list_prompts(cursor: cursor)
-        all_prompts.concat(page.prompts)
-        next_cursor = page.next_cursor
-        break if next_cursor.nil? || seen.include?(next_cursor)
-
-        seen << next_cursor
-        cursor = next_cursor
-      end
-
-      all_prompts
+      fetch_all_pages { |cursor| list_prompts(cursor: cursor) }.flat_map(&:prompts)
     end
 
     # Calls a tool via the transport layer and returns the full response from the server.
@@ -379,6 +323,27 @@ module MCP
     end
 
     private
+
+    # Walks every page of a list endpoint, following `next_cursor`, and returns
+    # the page results. The `seen` set guards against a server that repeats or
+    # cycles cursors, so the loop always terminates.
+    def fetch_all_pages
+      pages = []
+      seen = Set.new
+      cursor = nil
+
+      loop do
+        page = yield(cursor)
+        pages << page
+        next_cursor = page.next_cursor
+        break if next_cursor.nil? || seen.include?(next_cursor)
+
+        seen << next_cursor
+        cursor = next_cursor
+      end
+
+      pages
+    end
 
     def request(method:, params: nil)
       request_body = {


### PR DESCRIPTION
`#tools`, `#resources`, `#resource_templates`, and `#prompts` each repeated the same loop to follow `next_cursor` and collect every page, differing only in the `list_*` method called and the field read from each page. Move that loop into a single private `fetch_all_pages` helper so the four methods become one-liners and the cursor-cycle guard lives in one place.

Behavior is unchanged, the existing `MCP::Client` list tests cover it.

<!-- Provide a brief summary of your changes -->

## Motivation and Context
`MCP::Client#tools`, `#resources`, `#resource_templates`, and `#prompts` each followed the server's pagination the same way: start with no cursor, request a page, collect its items, follow `next_cursor`, and stop when the cursor is absent or repeats. The four methods were identical apart from which `list_*` method they called and which field they read from each page, so the same loop, including the guard against a server that returns a repeated or cyclic cursor was written out four times. (The four whole-collection methods were introduced alongside pagination in #320.)

This moves that loop into a single private `fetch_all_pages` helper. Each of the four methods becomes a one-line call describing what it fetches, and the cursor-following logic now lives in one place instead of four.

## How Has This Been Tested?
`rake test` and `rake rubocop` pass locally. The behavior is unchanged the cursor loop is moved into the helper as written. So the existing `MCP::Client` list tests continue to cover these methods.

## Breaking Changes
None. `#tools`, `#resources`, `#resource_templates`, and `#prompts` keep the same signatures and return the same values; only their shared internals were extracted into a private helper.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed