### PR TITLE
Preserve JSON-RPC error response ids

### DIFF
--- a/lib/json_rpc_handler.rb
+++ b/lib/json_rpc_handler.rb
@@ -79,7 +79,7 @@ module JsonRpcHandler
       'Method name must be a string and not start with "rpc."'
     end
 
-    return error_response(id: :unknown_id, id_validation_pattern: id_validation_pattern, error: {
+    return error_response(id: id, id_validation_pattern: id_validation_pattern, error: {
       code: ErrorCode::INVALID_REQUEST,
       message: "Invalid Request",
       data: error,

--- a/test/json_rpc_handler_test.rb
+++ b/test/json_rpc_handler_test.rb
@@ -36,13 +36,14 @@ describe JsonRpcHandler do
     end
 
     it "returns an error when jsonrpc is not 2.0" do
-      handle jsonrpc: "3.0", id: 1, method: "add", params: { a: 1, b: 2 }
+      handle jsonrpc: "3.0", id: 3, method: "add", params: { a: 1, b: 2 }
 
       assert_rpc_error expected_error: {
         code: -32600,
         message: "Invalid Request",
         data: "JSON-RPC version must be 2.0",
       }
+      assert_equal 3, @response[:id]
     end
 
     # method
@@ -51,13 +52,14 @@ describe JsonRpcHandler do
     #   used for anything else.
 
     it "returns an error when method is not a string" do
-      handle jsonrpc: "2.0", id: 1, method: 42, params: { a: 1, b: 2 }
+      handle jsonrpc: "2.0", id: 8, method: 42, params: { a: 1, b: 2 }
 
       assert_rpc_error expected_error: {
         code: -32600,
         message: "Invalid Request",
         data: 'Method name must be a string and not start with "rpc."',
       }
+      assert_equal 8, @response[:id]
     end
 
     it "returns an error when method begins with 'rpc.'" do
@@ -756,8 +758,19 @@ describe JsonRpcHandler do
       assert_nil @response
     end
 
-    it "returns an error with the id set to nil when the request is invalid" do
-      handle_json({ jsonrpc: "0.0", id: 1, method: "add", params: { a: 1, b: 2 } }.to_json)
+    it "returns an error with the request id when the JSON-RPC version is missing" do
+      handle_json({ id: 4, method: "add", params: { a: 1, b: 2 } }.to_json)
+
+      assert_rpc_error expected_error: {
+        code: -32600,
+        message: "Invalid Request",
+        data: "JSON-RPC version must be 2.0",
+      }
+      assert_equal 4, @response[:id]
+    end
+
+    it "returns an error with the id set to nil when the request id is invalid" do
+      handle_json({ jsonrpc: "2.0", id: {}, method: "add", params: { a: 1, b: 2 } }.to_json)
 
       assert_nil @response[:id]
     end


### PR DESCRIPTION
## Summary

Fixes #398.

## Changes

- Preserve recoverable JSON-RPC request ids when request-envelope validation returns an Invalid Request error.
- Add regressions for an unsupported JSON-RPC version, a missing JSON-RPC version through `handle_json`, and a non-string `method`.
- Keep invalid request ids returning `id: null`.

## Verification

```sh
bundle exec ruby -I lib -I test test/json_rpc_handler_test.rb
bundle exec ruby -I lib -I test test/mcp/server_test.rb test/mcp/server/transports/stdio_transport_test.rb test/mcp/server/transports/streamable_http_transport_test.rb
bundle exec rake test
bundle exec rake rubocop
bundle exec yard --no-output
```
