### PR TITLE
Add `annotations` field to `MCP::Resource` and `MCP::ResourceTemplate` per MCP specification

### DIFF
--- a/lib/mcp/resource.rb
+++ b/lib/mcp/resource.rb
@@ -5,15 +5,16 @@ require_relative "resource/embedded"
 
 module MCP
   class Resource
-    attr_reader :uri, :name, :title, :description, :icons, :mime_type, :size, :meta
+    attr_reader :uri, :name, :title, :description, :icons, :mime_type, :annotations, :size, :meta
 
-    def initialize(uri:, name:, title: nil, description: nil, icons: [], mime_type: nil, size: nil, meta: nil)
+    def initialize(uri:, name:, title: nil, description: nil, icons: [], mime_type: nil, annotations: nil, size: nil, meta: nil)
       @uri = uri
       @name = name
       @title = title
       @description = description
       @icons = icons
       @mime_type = mime_type
+      @annotations = annotations
       @size = size
       @meta = meta
     end
@@ -26,6 +27,7 @@ module MCP
         description: description,
         icons: icons&.then { |icons| icons.empty? ? nil : icons.map(&:to_h) },
         mimeType: mime_type,
+        annotations: annotations&.to_h,
         size: size,
         _meta: meta,
       }.compact

--- a/lib/mcp/resource_template.rb
+++ b/lib/mcp/resource_template.rb
@@ -2,15 +2,16 @@
 
 module MCP
   class ResourceTemplate
-    attr_reader :uri_template, :name, :title, :description, :icons, :mime_type, :meta
+    attr_reader :uri_template, :name, :title, :description, :icons, :mime_type, :annotations, :meta
 
-    def initialize(uri_template:, name:, title: nil, description: nil, icons: [], mime_type: nil, meta: nil)
+    def initialize(uri_template:, name:, title: nil, description: nil, icons: [], mime_type: nil, annotations: nil, meta: nil)
       @uri_template = uri_template
       @name = name
       @title = title
       @description = description
       @icons = icons
       @mime_type = mime_type
+      @annotations = annotations
       @meta = meta
     end
 
@@ -22,6 +23,7 @@ module MCP
         description: description,
         icons: icons&.then { |icons| icons.empty? ? nil : icons.map(&:to_h) },
         mimeType: mime_type,
+        annotations: annotations&.to_h,
         _meta: meta,
       }.compact
     end

--- a/test/mcp/resource_template_test.rb
+++ b/test/mcp/resource_template_test.rb
@@ -53,5 +53,23 @@ module MCP
 
       assert_equal meta, resource_template.to_h[:_meta]
     end
+
+    test "#to_h omits annotations when nil" do
+      resource_template = ResourceTemplate.new(uri_template: "file:///{path}", name: "template_without_annotations")
+
+      refute resource_template.to_h.key?(:annotations)
+    end
+
+    test "#to_h includes annotations when present" do
+      annotations = Annotations.new(audience: ["user"], priority: 0.8, last_modified: "2025-01-12T15:00:58Z")
+      resource_template = ResourceTemplate.new(
+        uri_template: "file:///{path}",
+        name: "template_with_annotations",
+        annotations: annotations,
+      )
+
+      expected = { audience: ["user"], priority: 0.8, lastModified: "2025-01-12T15:00:58Z" }
+      assert_equal expected, resource_template.to_h[:annotations]
+    end
   end
 end

--- a/test/mcp/resource_test.rb
+++ b/test/mcp/resource_test.rb
@@ -67,5 +67,19 @@ module MCP
 
       assert_equal 0, resource.to_h[:size]
     end
+
+    test "#to_h omits annotations when nil" do
+      resource = Resource.new(uri: "file:///test.txt", name: "resource_without_annotations")
+
+      refute resource.to_h.key?(:annotations)
+    end
+
+    test "#to_h includes annotations when present" do
+      annotations = Annotations.new(audience: ["user"], priority: 0.8, last_modified: "2025-01-12T15:00:58Z")
+      resource = Resource.new(uri: "file:///test.txt", name: "resource_with_annotations", annotations: annotations)
+
+      expected = { audience: ["user"], priority: 0.8, lastModified: "2025-01-12T15:00:58Z" }
+      assert_equal expected, resource.to_h[:annotations]
+    end
   end
 end


### PR DESCRIPTION
## Motivation and Context

The MCP specification defines an optional `annotations` field on both the `Resource` and `ResourceTemplate` types ([spec](https://modelcontextprotocol.io/specification/2025-11-25/server/resources#annotations)), but the Ruby SDK is the only official SDK that does not wire it up — TypeScript, Python, and PHP all implement it.

The `MCP::Annotations` class already exists; this PR connects it. The field accepts an `MCP::Annotations` instance rather than a raw hash, for consistency with other typed fields and to get `lastModified` key normalization for free.

## How Has This Been Tested?

Added tests in `test/mcp/resource_test.rb` and `test/mcp/resource_template_test.rb`:

- `#to_h` omits `annotations` when nil
- `#to_h` includes `annotations` when present (also asserting that `last_modified` is serialized as `lastModified`)

The full unit suite and RuboCop pass locally.

## Breaking Changes

None. `annotations:` is a new optional keyword argument defaulting to `nil`, and it is omitted from `#to_h` output when not set.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
