### PR TITLE
chore: require rubocop-minitest 0.39

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ source "https://rubygems.org"
 gemspec
 
 # Specify development dependencies below
-gem "rubocop-minitest", require: false
+gem "rubocop-minitest", ">= 0.39.0", require: false
 gem "rubocop-rake", require: false
 gem "rubocop-shopify", ">= 2.18", require: false if RUBY_VERSION >= "3.1"
 


### PR DESCRIPTION
# TL;DR
Require `rubocop-minitest` 0.39.0 or newer so `Minitest/AssertEmptyLiteral` uses its newer default disabled state.

# Context
Clean `main` reported 35 `Minitest/AssertEmptyLiteral` offenses with `rubocop-minitest` 0.38.2. That cop was disabled by default in `rubocop-minitest` 0.39.0 because `assert_empty` can hide whether the intended expected literal was `[]` or `{}`.

# Changes
- Add a minimum `rubocop-minitest` version of `0.39.0` in the Gemfile.
- Leave the existing assertions unchanged.

# Tophatting
- `GEM_HOME="$PWD/.gem-test" GEM_PATH="$PWD/.gem-test:/nix/store/jh918yiwd5cs4pjg005ac32m2q7ckw3l-ruby-4.0.5/lib/ruby/gems/4.0.0" bundle exec rake rubocop`
- `GEM_HOME="$PWD/.gem-test" GEM_PATH="$PWD/.gem-test:/nix/store/jh918yiwd5cs4pjg005ac32m2q7ckw3l-ruby-4.0.5/lib/ruby/gems/4.0.0" bundle exec rake test`
- `git diff --check`
