### PR TITLE
Set OIDC `application_type` on Dynamic Client Registration per SEP-837

### DIFF
--- a/README.md
+++ b/README.md
@@ -2029,6 +2029,8 @@ Required keyword arguments to `Provider.new`:
 
 - `client_metadata`: Hash sent to the authorization server's Dynamic Client Registration endpoint. Must include `redirect_uris`, `grant_types`, `response_types`,
   `token_endpoint_auth_method`. `redirect_uri` (below) must appear in this list, otherwise the constructor raises `Provider::UnregisteredRedirectURIError`.
+  When `application_type` is omitted, the SDK infers `"native"` or `"web"` from `redirect_uris` per SEP-837 before registering (loopback or custom-scheme URIs are native);
+  an explicit value always wins.
 - `redirect_uri`: String. Must use HTTPS or be a loopback URL (`localhost`, `127.0.0.0/8`, `::1`); other values raise `Provider::InsecureRedirectURIError`.
 - `redirect_handler`: Callable invoked with the fully-built authorization `URI`. Typically opens the user's browser.
 - `callback_handler`: Callable that returns `[code, state]` after the user is redirected back to `redirect_uri`.

--- a/lib/mcp/client/oauth/discovery.rb
+++ b/lib/mcp/client/oauth/discovery.rb
@@ -237,6 +237,23 @@ module MCP
             false
           end
 
+          # Infers the OIDC Dynamic Client Registration `application_type` for a client from its `redirect_uris`.
+          # Per SEP-837, MCP clients MUST specify an appropriate application type during Dynamic Client Registration
+          # so the authorization server can apply the matching redirect URI policy.
+          #
+          # Returns `"native"` when every redirect URI is a native-app URI: a custom non-http(s) scheme (RFC 8252 Section 7.1)
+          # or an http(s) URI whose host is a loopback address (`localhost`, `127.0.0.0/8`, or `::1`, RFC 8252 Section 7.3).
+          # Returns `"web"` otherwise, including when `redirect_uris` is nil, empty, or contains an unparseable URI.
+          #
+          # - https://github.com/modelcontextprotocol/modelcontextprotocol/pull/837
+          # - https://openid.net/specs/openid-connect-registration-1_0.html#ClientMetadata
+          def infer_application_type(redirect_uris)
+            uris = Array(redirect_uris)
+            return "web" if uris.empty?
+
+            uris.all? { |uri| native_redirect_uri?(uri) } ? "native" : "web"
+          end
+
           # Like `canonicalize_url` but also strips query string, fragment, and
           # userinfo. This variant is used for identity comparison against
           # the request URL Faraday actually sends, which differs from the value
@@ -343,6 +360,20 @@ module MCP
             IPAddr.new(candidate)
           rescue IPAddr::Error
             nil
+          end
+
+          # A redirect URI counts as native when it uses a custom non-http(s) scheme
+          # (e.g. `com.example.app:/callback`) or when it is an http(s) URI whose host is
+          # a loopback address. A URI without a scheme or one that fails to parse is not native.
+          def native_redirect_uri?(url)
+            uri = URI.parse(url.to_s)
+            scheme = uri.scheme&.downcase
+            return false if scheme.nil?
+            return loopback_host?(uri.host) if ["http", "https"].include?(scheme)
+
+            true
+          rescue URI::InvalidURIError
+            false
           end
 
           def base_url(uri)

--- a/lib/mcp/client/oauth/flow.rb
+++ b/lib/mcp/client/oauth/flow.rb
@@ -367,7 +367,7 @@ module MCP
           end
 
           response = begin
-            http_post_json(registration_endpoint, @provider.client_metadata)
+            http_post_json(registration_endpoint, registration_client_metadata)
           rescue Faraday::Error => e
             raise AuthorizationError,
               "Dynamic client registration failed: #{e.class}: #{e.message}."
@@ -391,6 +391,20 @@ module MCP
 
           @provider.save_client_information(info)
           info
+        end
+
+        # Returns the client metadata to submit on Dynamic Client Registration.
+        # Per SEP-837, MCP clients MUST specify an appropriate OIDC `application_type`
+        # so the authorization server can apply the matching redirect URI policy.
+        # When the user did not set one explicitly, infer `"native"` vs `"web"` from
+        # the registered `redirect_uris`; an explicit value always wins.
+        # https://github.com/modelcontextprotocol/modelcontextprotocol/pull/837
+        def registration_client_metadata
+          metadata = @provider.client_metadata
+          return metadata if metadata[:application_type] || metadata["application_type"]
+
+          redirect_uris = metadata[:redirect_uris] || metadata["redirect_uris"]
+          metadata.merge("application_type" => Discovery.infer_application_type(redirect_uris))
         end
 
         # Reads `key` from a `client_information` hash that may use either string or

--- a/lib/mcp/client/oauth/provider.rb
+++ b/lib/mcp/client/oauth/provider.rb
@@ -13,6 +13,9 @@ module MCP
       # - `client_metadata`  - Hash sent to the authorization server's Dynamic Client
       #   Registration endpoint. Must include at minimum `redirect_uris`,
       #   `grant_types`, `response_types`, and `token_endpoint_auth_method`.
+      #   When `application_type` is omitted, the SDK infers `"native"` or `"web"`
+      #   from `redirect_uris` per SEP-837 before registering; an explicit value
+      #   always wins.
       # - `redirect_uri`     - String: the redirect URI used for the authorization
       #   request. Must be one of `redirect_uris` in `client_metadata`.
       # - `redirect_handler` - Callable invoked with the fully-built authorization

--- a/test/mcp/client/oauth/discovery_test.rb
+++ b/test/mcp/client/oauth/discovery_test.rb
@@ -158,6 +158,39 @@ module MCP
           )
         end
 
+        def test_infer_application_type_returns_native_for_loopback_http_redirect_uris
+          uris = ["http://localhost:0/callback", "http://127.0.0.1:8080/cb", "http://[::1]/cb"]
+
+          assert_equal("native", Discovery.infer_application_type(uris))
+        end
+
+        def test_infer_application_type_returns_native_for_custom_scheme_redirect_uris
+          assert_equal("native", Discovery.infer_application_type(["com.example.app:/oauth/callback"]))
+        end
+
+        def test_infer_application_type_returns_web_for_https_redirect_uris
+          assert_equal("web", Discovery.infer_application_type(["https://app.example.com/callback"]))
+        end
+
+        def test_infer_application_type_returns_web_when_any_redirect_uri_is_not_native
+          uris = ["http://localhost:0/callback", "https://app.example.com/callback"]
+
+          assert_equal("web", Discovery.infer_application_type(uris))
+        end
+
+        def test_infer_application_type_returns_web_for_localhost_lookalike_host
+          assert_equal("web", Discovery.infer_application_type(["http://localhost.example.com/cb"]))
+        end
+
+        def test_infer_application_type_returns_web_for_nil_or_empty_redirect_uris
+          assert_equal("web", Discovery.infer_application_type(nil))
+          assert_equal("web", Discovery.infer_application_type([]))
+        end
+
+        def test_infer_application_type_returns_web_for_unparseable_redirect_uri
+          assert_equal("web", Discovery.infer_application_type(["http://[invalid"]))
+        end
+
         def test_canonicalize_url_normalizes_scheme_host_port_and_path
           assert_equal(
             "https://srv.example.com/mcp",

--- a/test/mcp/client/oauth/flow_test.rb
+++ b/test/mcp/client/oauth/flow_test.rb
@@ -200,6 +200,62 @@ module MCP
           end
         end
 
+        # Runs the full authorization flow with a minimal provider so tests can assert on
+        # the Dynamic Client Registration request body. The default loopback redirect URI
+        # exercises SEP-837's `"native"` inference; passing an HTTPS `redirect_uri` exercises
+        # the `"web"` inference.
+        def run_authorization_flow(redirect_uri: "http://localhost:0/callback", client_metadata_extra: {})
+          state_holder = {}
+          provider = Provider.new(
+            client_metadata: {
+              redirect_uris: [redirect_uri],
+              grant_types: ["authorization_code"],
+              response_types: ["code"],
+              token_endpoint_auth_method: "none",
+            }.merge(client_metadata_extra),
+            redirect_uri: redirect_uri,
+            redirect_handler: ->(url) { state_holder[:state] = URI.decode_www_form(url.query).to_h.fetch("state") },
+            callback_handler: -> { ["test-auth-code", state_holder[:state]] },
+          )
+
+          Flow.new(provider: provider).run!(server_url: @server_url, resource_metadata_url: @prm_url)
+        end
+
+        def test_run_registers_native_application_type_for_loopback_redirect_uri
+          run_authorization_flow
+
+          assert_requested(:post, "#{@auth_base}/register") do |req|
+            JSON.parse(req.body)["application_type"] == "native"
+          end
+        end
+
+        def test_run_registers_web_application_type_for_https_redirect_uri
+          run_authorization_flow(redirect_uri: "https://app.example.com/callback")
+
+          assert_requested(:post, "#{@auth_base}/register") do |req|
+            JSON.parse(req.body)["application_type"] == "web"
+          end
+        end
+
+        def test_run_does_not_override_explicit_application_type
+          run_authorization_flow(client_metadata_extra: { application_type: "web" })
+
+          assert_requested(:post, "#{@auth_base}/register") do |req|
+            JSON.parse(req.body)["application_type"] == "web"
+          end
+        end
+
+        def test_run_does_not_override_explicit_string_keyed_application_type
+          run_authorization_flow(
+            redirect_uri: "https://app.example.com/callback",
+            client_metadata_extra: { "application_type" => "native" },
+          )
+
+          assert_requested(:post, "#{@auth_base}/register") do |req|
+            JSON.parse(req.body)["application_type"] == "native"
+          end
+        end
+
         def test_run_completes_full_authorization_flow
           captured_authorization_url = nil
           state_value = nil


### PR DESCRIPTION
## Motivation and Context

SEP-837 (modelcontextprotocol/modelcontextprotocol#837, merged for the 2026-07-28 spec release) updates the authorization spec to require MCP clients to specify an appropriate OIDC `application_type` (`"native"` vs `"web"`) during Dynamic Client Registration, so the authorization server can apply the matching redirect URI policy and native and web clients do not collide on redirect URI validation rules.

This mirrors the approach taken by the TypeScript SDK (typescript-sdk#2266) and the Python SDK (python-sdk#2784):

- `MCP::Client::OAuth::Discovery.infer_application_type(redirect_uris)` returns `"native"` when every redirect URI is a native-app URI (a custom  non-http(s) scheme per RFC 8252 Section 7.1, or an http(s) URI with a loopback host per RFC 8252 Section 7.3) and `"web"` otherwise, including for nil, empty, or unparseable input. Loopback detection reuses the existing `loopback_host?` helper, so lookalike hosts such as `localhost.example.com` or `127.attacker.com` are not treated as native.
- `Flow#ensure_client_registered` now posts the metadata through the new `registration_client_metadata` helper, which merges the inferred `application_type` into the DCR request body only when the user did not set one explicitly (symbol or string key); an explicit value always wins.

Resolves #375.

## How Has This Been Tested?

New tests in `test/mcp/client/oauth/discovery_test.rb` cover the inference: loopback http URIs (IPv4, IPv6, `localhost`), custom schemes, https URIs, mixed lists, the `localhost.example.com` lookalike, nil/empty input, and unparseable URIs.

New tests in `test/mcp/client/oauth/flow_test.rb` assert on the actual DCR request body via WebMock `assert_requested`: loopback redirect URI registers `"application_type": "native"`, an HTTPS redirect URI registers `"web"`, and an explicit `application_type` (symbol- or string-keyed) is never overridden.

## Breaking Changes

None. The DCR request body gains an `application_type` member only when the user has not specified one; RFC 7591 requires authorization servers to accept and use known metadata fields, and OIDC-registration servers already default this field to `"web"` when absent.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
