### PR TITLE
Add range validation for `MCP::Annotations#priority` per MCP specification

### DIFF
--- a/lib/mcp/annotations.rb
+++ b/lib/mcp/annotations.rb
@@ -5,6 +5,8 @@ module MCP
     attr_reader :audience, :priority, :last_modified
 
     def initialize(audience: nil, priority: nil, last_modified: nil)
+      raise ArgumentError, "The value of priority must be between 0 and 1." if priority && !priority.between?(0, 1)
+
       @audience = audience
       @priority = priority
       @last_modified = last_modified

--- a/test/mcp/annotations_test.rb
+++ b/test/mcp/annotations_test.rb
@@ -55,5 +55,31 @@ module MCP
 
       assert_equal({ lastModified: timestamp }, annotations.to_h)
     end
+
+    def test_valid_priority_at_lower_bound
+      assert_nothing_raised do
+        Annotations.new(priority: 0)
+      end
+    end
+
+    def test_valid_priority_at_upper_bound
+      assert_nothing_raised do
+        Annotations.new(priority: 1)
+      end
+    end
+
+    def test_invalid_priority_above_upper_bound
+      exception = assert_raises(ArgumentError) do
+        Annotations.new(priority: 1.5)
+      end
+      assert_equal("The value of priority must be between 0 and 1.", exception.message)
+    end
+
+    def test_invalid_priority_below_lower_bound
+      exception = assert_raises(ArgumentError) do
+        Annotations.new(priority: -0.1)
+      end
+      assert_equal("The value of priority must be between 0 and 1.", exception.message)
+    end
   end
 end


### PR DESCRIPTION
## Motivation and Context

The MCP specification constrains `Annotations.priority` to the 0–1 range (`@minimum 0`, `@maximum 1`) ([schema](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/main/schema/2025-06-18/schema.ts)), but the Ruby SDK accepts any value. The other official SDKs already enforce this (TypeScript, Python, and PHP).

This follows the existing pattern in `MCP::Icon`, which validates its constrained `theme` value in the constructor and raises `ArgumentError`.

## How Has This Been Tested?

Added tests in `test/mcp/annotations_test.rb`:

- valid `priority` at the lower (0) and upper (1) bounds is accepted
- out-of-range `priority` (above 1, below 0) raises `ArgumentError`

The full unit suite and RuboCop pass locally.

## Breaking Changes

Strictly speaking yes: a caller that currently passes an out-of-range `priority` (e.g. `priority: 99`) will now get an `ArgumentError`. Such values already violate the MCP specification, and `nil` / in-range values are unaffected.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
