### PR TITLE
Fix a build error in the Ruby 3.1 CI matrix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,8 @@ gem "rackup", ">= 2.1.0"
 gem "activesupport"
 # Fix io-console install error when Ruby 3.0.
 gem "debug" if RUBY_VERSION >= "3.1"
+# Avoid i18n 1.15.0, which breaks on Ruby 3.1 (ruby-i18n/i18n#735).
+gem "i18n", "!= 1.15.0"
 gem "rake", "~> 13.0"
 gem "sorbet-static-and-runtime" if RUBY_VERSION >= "3.0"
 gem "yard", "~> 0.9"


### PR DESCRIPTION
## Motivation and Context

This resolves the following build failure that occurs when using Ruby 3.1 with I18n 1.15.0:

```console
$ bundle exec rake
(snip)

/Users/koic/.rbenv/versions/3.1.5/lib/ruby/gems/3.1.0/gems/i18n-1.15.0/lib/i18n.rb:58:
in `config': undefined method `[]' for Fiber:Class (NoMethodError)

      current = Fiber[:i18n_config] || self.config = I18n::Config.new
                     ^^^^^^^^^^^^^^
        from /Users/koic/.rbenv/versions/3.1.5/lib/ruby/gems/3.1.0/gems/i18n-1.15.0/lib/i18n.rb:88:in `load_path'
```

https://github.com/modelcontextprotocol/ruby-sdk/actions/runs/27724973112/job/82025136923

According to the report in https://github.com/ruby-i18n/i18n/issues/735, this issue has been fixed in I18n 1.15.1 and later. However, the already released I18n 1.15.0 still triggers the build error.

While this could potentially be addressed in a better way on the I18n side, this change updates the Gemfile to avoid using I18n 1.15.0, which is known to cause the issue.

## How Has This Been Tested?

The build error described above has been resolved.

## Breaking Changes

None.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
