### PR TITLE
Add `audience` role validation for `MCP::Annotations` per MCP specification

### DIFF
--- a/lib/mcp/annotations.rb
+++ b/lib/mcp/annotations.rb
@@ -2,9 +2,14 @@
 
 module MCP
   class Annotations
+    SUPPORTED_AUDIENCES = ["user", "assistant"].freeze
+
     attr_reader :audience, :priority, :last_modified
 
     def initialize(audience: nil, priority: nil, last_modified: nil)
+      if audience && !(audience.is_a?(Array) && audience.all? { |role| SUPPORTED_AUDIENCES.include?(role) })
+        raise ArgumentError, 'The value of audience must be an array of "user" or "assistant".'
+      end
       raise ArgumentError, "The value of priority must be between 0 and 1." if priority && !priority.between?(0, 1)
 
       @audience = audience

--- a/test/mcp/annotations_test.rb
+++ b/test/mcp/annotations_test.rb
@@ -5,24 +5,24 @@ require "test_helper"
 module MCP
   class AnnotationsTest < ActiveSupport::TestCase
     def test_initialization
-      annotations = Annotations.new(audience: ["developers"], priority: 0.8)
+      annotations = Annotations.new(audience: ["user"], priority: 0.8)
 
-      assert_equal(["developers"], annotations.audience)
+      assert_equal(["user"], annotations.audience)
       assert_equal(0.8, annotations.priority)
       assert_nil(annotations.last_modified)
 
-      assert_equal({ audience: ["developers"], priority: 0.8 }, annotations.to_h)
+      assert_equal({ audience: ["user"], priority: 0.8 }, annotations.to_h)
     end
 
     def test_initialization_with_all_attributes
       timestamp = Time.utc(2025, 1, 12, 15, 0, 58).iso8601
-      annotations = Annotations.new(audience: ["developers"], priority: 0.8, last_modified: timestamp)
+      annotations = Annotations.new(audience: ["user"], priority: 0.8, last_modified: timestamp)
 
-      assert_equal(["developers"], annotations.audience)
+      assert_equal(["user"], annotations.audience)
       assert_equal(0.8, annotations.priority)
       assert_equal(timestamp, annotations.last_modified)
 
-      assert_equal({ audience: ["developers"], priority: 0.8, lastModified: timestamp }, annotations.to_h)
+      assert_equal({ audience: ["user"], priority: 0.8, lastModified: timestamp }, annotations.to_h)
     end
 
     def test_initialization_by_default
@@ -36,13 +36,13 @@ module MCP
     end
 
     def test_initialization_with_partial_attributes
-      annotations = Annotations.new(audience: ["developers"])
+      annotations = Annotations.new(audience: ["user"])
 
-      assert_equal(["developers"], annotations.audience)
+      assert_equal(["user"], annotations.audience)
       assert_nil(annotations.priority)
       assert_nil(annotations.last_modified)
 
-      assert_equal({ audience: ["developers"] }, annotations.to_h)
+      assert_equal({ audience: ["user"] }, annotations.to_h)
     end
 
     def test_initialization_with_last_modified_only
@@ -80,6 +80,51 @@ module MCP
         Annotations.new(priority: -0.1)
       end
       assert_equal("The value of priority must be between 0 and 1.", exception.message)
+    end
+
+    def test_valid_audience_with_user
+      assert_nothing_raised do
+        Annotations.new(audience: ["user"])
+      end
+    end
+
+    def test_valid_audience_with_assistant
+      assert_nothing_raised do
+        Annotations.new(audience: ["assistant"])
+      end
+    end
+
+    def test_valid_audience_with_multiple_roles
+      assert_nothing_raised do
+        Annotations.new(audience: ["user", "assistant"])
+      end
+    end
+
+    def test_valid_audience_with_empty_array
+      assert_nothing_raised do
+        Annotations.new(audience: [])
+      end
+    end
+
+    def test_invalid_audience_with_unknown_role
+      exception = assert_raises(ArgumentError) do
+        Annotations.new(audience: ["developers"])
+      end
+      assert_equal('The value of audience must be an array of "user" or "assistant".', exception.message)
+    end
+
+    def test_invalid_audience_with_mixed_roles
+      exception = assert_raises(ArgumentError) do
+        Annotations.new(audience: ["user", "developers"])
+      end
+      assert_equal('The value of audience must be an array of "user" or "assistant".', exception.message)
+    end
+
+    def test_invalid_audience_when_not_array
+      exception = assert_raises(ArgumentError) do
+        Annotations.new(audience: "user")
+      end
+      assert_equal('The value of audience must be an array of "user" or "assistant".', exception.message)
     end
   end
 end


### PR DESCRIPTION
## Motivation and Context

The MCP specification constrains [`Annotations.audience`](https://modelcontextprotocol.io/specification/2025-11-25/schema#annotations) to an array of `Role` values (`"user"` or `"assistant"`), but the Ruby SDK accepts any value. The other official SDKs already enforce this — [TypeScript](https://github.com/modelcontextprotocol/typescript-sdk/blob/main/packages/core/src/types/schemas.ts#L857-L861), [Python](https://github.com/modelcontextprotocol/python-sdk/blob/main/src/mcp/types/_types.py#L768-L771), and [PHP](https://github.com/modelcontextprotocol/php-sdk/blob/main/src/Schema/Annotations.php#L46-L52).

This follows the existing pattern in [`MCP::Icon`](https://github.com/modelcontextprotocol/ruby-sdk/blob/main/lib/mcp/icon.rb#L10), which validates its constrained `theme` value in the constructor and raises `ArgumentError`.

## How Has This Been Tested?

Added tests in `test/mcp/annotations_test.rb`:

- valid `audience` (`["user"]`, `["assistant"]`, `["user", "assistant"]`,
  and an empty array) is accepted
- an unknown role, a mixed valid/invalid array, or a non-array `audience`
  raises `ArgumentError`

Existing tests used `["developers"]`, which is not a valid `Role`, and are
updated to `["user"]`.

The full unit suite and RuboCop pass locally.

## Breaking Changes

Strictly speaking yes: a caller that currently passes an invalid `audience`
(e.g. `["developers"]`) will now get an `ArgumentError`. Such values already
violate the MCP specification, and `nil` / valid-role values are unaffected.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
