### PR TITLE
docs: annotate Roots, Sampling, and Logging as deprecated per SEP-2577

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Deprecated
+
+- Annotate Roots, Sampling, and Logging APIs as deprecated per SEP-2577 (#429)
+
 ## [0.22.0] - 2026-06-27
 
 ### Added

--- a/lib/mcp/server.rb
+++ b/lib/mcp/server.rb
@@ -256,6 +256,9 @@ module MCP
       report_exception(e, { notification: "resources_list_changed" })
     end
 
+    # @deprecated MCP Logging (`logging/setLevel` and `notifications/message`)
+    #   is deprecated as of MCP protocol version 2026-07-28 (SEP-2577).
+    #   Use stderr or OpenTelemetry instead.
     def notify_log_message(data:, level:, logger: nil)
       return unless @transport
       return unless logging_message_notification&.should_notify?(level)
@@ -272,6 +275,10 @@ module MCP
     # Called when a client notifies the server that its filesystem roots have changed.
     #
     # @yield [params] The notification params (typically `nil`).
+    # @deprecated MCP Roots (`roots/list` and
+    #   `notifications/roots/list_changed`) is deprecated as of MCP protocol
+    #   version 2026-07-28 (SEP-2577). Use tool parameters, resource URIs,
+    #   server configuration, or environment variables instead.
     def roots_list_changed_handler(&block)
       @handlers[Methods::NOTIFICATIONS_ROOTS_LIST_CHANGED] = block
     end

--- a/lib/mcp/server_context.rb
+++ b/lib/mcp/server_context.rb
@@ -35,6 +35,9 @@ module MCP
     # @param data [Object] The log data to send.
     # @param level [String] Log level (e.g., `"debug"`, `"info"`, `"error"`).
     # @param logger [String, nil] Logger name.
+    # @deprecated MCP Logging (`logging/setLevel` and `notifications/message`)
+    #   is deprecated as of MCP protocol version 2026-07-28 (SEP-2577).
+    #   Use stderr or OpenTelemetry instead.
     def notify_log_message(data:, level:, logger: nil)
       return unless @notification_target
 
@@ -51,6 +54,10 @@ module MCP
     end
 
     # Delegates to the session so the request is scoped to the originating client.
+    # @deprecated MCP Roots (`roots/list` and
+    #   `notifications/roots/list_changed`) is deprecated as of MCP protocol
+    #   version 2026-07-28 (SEP-2577). Use tool parameters, resource URIs,
+    #   server configuration, or environment variables instead.
     def list_roots
       if @notification_target.respond_to?(:list_roots)
         @notification_target.list_roots(related_request_id: @related_request_id)
@@ -84,6 +91,9 @@ module MCP
     # Delegates to the session so the request is scoped to the originating client.
     # Falls back to `@context` (via `method_missing`) when `@notification_target`
     # does not support sampling.
+    # @deprecated MCP Sampling (`sampling/createMessage`) is deprecated as of
+    #   MCP protocol version 2026-07-28 (SEP-2577). Use direct LLM provider
+    #   APIs instead.
     def create_sampling_message(**kwargs)
       if @notification_target.respond_to?(:create_sampling_message)
         @notification_target.create_sampling_message(**kwargs, related_request_id: @related_request_id)

--- a/lib/mcp/server_session.rb
+++ b/lib/mcp/server_session.rb
@@ -98,6 +98,10 @@ module MCP
     end
 
     # Sends a `roots/list` request scoped to this session.
+    # @deprecated MCP Roots (`roots/list` and
+    #   `notifications/roots/list_changed`) is deprecated as of MCP protocol
+    #   version 2026-07-28 (SEP-2577). Use tool parameters, resource URIs,
+    #   server configuration, or environment variables instead.
     def list_roots(related_request_id: nil)
       unless client_capabilities&.dig(:roots)
         raise "Client does not support roots."
@@ -115,6 +119,9 @@ module MCP
     end
 
     # Sends a `sampling/createMessage` request scoped to this session.
+    # @deprecated MCP Sampling (`sampling/createMessage`) is deprecated as of
+    #   MCP protocol version 2026-07-28 (SEP-2577). Use direct LLM provider
+    #   APIs instead.
     def create_sampling_message(related_request_id: nil, **kwargs)
       params = @server.build_sampling_params(client_capabilities, **kwargs)
       send_to_transport_request(Methods::SAMPLING_CREATE_MESSAGE, params, related_request_id: related_request_id)
@@ -188,6 +195,9 @@ module MCP
     end
 
     # Sends a log message notification to this session only.
+    # @deprecated MCP Logging (`logging/setLevel` and `notifications/message`)
+    #   is deprecated as of MCP protocol version 2026-07-28 (SEP-2577).
+    #   Use stderr or OpenTelemetry instead.
     def notify_log_message(data:, level:, logger: nil, related_request_id: nil)
       effective_logging = @logging_message_notification || @server.logging_message_notification
       return unless effective_logging&.should_notify?(level)


### PR DESCRIPTION
# TL;DR
Add advisory YARD `@deprecated` annotations for the Roots, Sampling, and Logging APIs deprecated by SEP-2577, without the protocol-version-gated runtime behavior change.

# Context
SEP-2577 deprecates Roots, Sampling, and Logging in the `2026-07-28` protocol version. This PR splits the advisory annotations out of #406 per @koic's feedback, so the documentation can land now while the behavioral switch waits until the `2026-07-28` release is closer.

Refs #390

# Changes
- Add YARD `@deprecated` notes to the server, server-context, and server-session APIs for roots (`roots_list_changed_handler`, `list_roots`), sampling (`create_sampling_message`), and logging (`notify_log_message`).
- Update the changelog.

Deliberately **not** included (deferred to a follow-up once `2026-07-28` is closer to release):
- Adding `2026-07-28` to `SUPPORTED_STABLE_PROTOCOL_VERSIONS`.
- The protocol-version-gated `Kernel.warn` runtime warnings and the `ProtocolDeprecations` helper.

# Testing
Docs-only change (YARD comments + changelog). No behavior change; relies on CI for lint/test validation.
