### PR TITLE
Validate OAuth authorization response issuers per SEP-2468

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Validate RFC 9207 `iss` authorization response parameters in OAuth client flows per SEP-2468
+
 ### Deprecated
 
 - Annotate Roots, Sampling, and Logging APIs as deprecated per SEP-2577 (#429)

--- a/README.md
+++ b/README.md
@@ -2075,6 +2075,9 @@ pass an `MCP::Client::OAuth::Provider` to the transport instead of a static `Aut
 - On a `403 Forbidden` whose `WWW-Authenticate` header carries `error="insufficient_scope"` (OAuth 2.0 step-up, RFC 6750 Section 3.1 and the MCP scope-selection-strategy),
   run a fresh authorization request for the union of the currently granted scope and the scope named in the challenge, then retry the failed request once.
   The refresh path is bypassed because refreshing would re-issue the same scope set the server just rejected. A `403` without that challenge is surfaced unchanged.
+- Validate the URL-form-decoded RFC 9207 `iss` parameter from authorization responses before exchanging the authorization code.
+  Any returned `iss` must exactly match the discovered issuer, even when the authorization server has not advertised support.
+  If the server advertises `authorization_response_iss_parameter_supported: true`, the callback must return the `iss` value.
 - Request the `offline_access` scope when `client_metadata[:grant_types]` includes `refresh_token` and the authorization server advertises `offline_access` in its metadata
   `scopes_supported` (SEP-2207). This is what lets the server issue the `refresh_token` used above. As an SDK-level safeguard, when the authorization server does not advertise
   `offline_access` the scope is also stripped from any other source (challenge, PRM, or provider-supplied scope) so a server that does not support it never receives it.
@@ -2097,7 +2100,10 @@ provider = MCP::Client::OAuth::Provider.new(
   },
   callback_handler: -> {
     # Capture the redirect (for example, by running a small HTTP listener on
-    # `redirect_uri`) and return [code, state] from the query string.
+    # `redirect_uri`) and return URL-form-decoded [code, state, iss] values
+    # from the query string.
+    # The `iss` value is optional unless the authorization server advertises
+    # `authorization_response_iss_parameter_supported: true`.
   },
 )
 
@@ -2118,7 +2124,8 @@ Required keyword arguments to `Provider.new`:
   an explicit value always wins.
 - `redirect_uri`: String. Must use HTTPS or be a loopback URL (`localhost`, `127.0.0.0/8`, `::1`); other values raise `Provider::InsecureRedirectURIError`.
 - `redirect_handler`: Callable invoked with the fully-built authorization `URI`. Typically opens the user's browser.
-- `callback_handler`: Callable that returns `[code, state]` after the user is redirected back to `redirect_uri`.
+- `callback_handler`: Callable that returns `[code, state]` or `[code, state, iss]` after the user is redirected back to `redirect_uri`.
+  Return URL-form-decoded query values, including the RFC 9207 `iss` parameter when present; the SDK rejects mismatched values and rejects missing `iss` when the authorization server advertises support.
 
 Optional keyword arguments:
 

--- a/conformance/client.rb
+++ b/conformance/client.rb
@@ -95,7 +95,7 @@ def build_oauth_provider(context, scenario:)
 
   callback_handler = -> do
     query = URI.decode_www_form(callback_holder.fetch(:url).query).to_h
-    [query["code"], query["state"]]
+    [query["code"], query["state"], query["iss"]]
   end
 
   MCP::Client::OAuth::Provider.new(

--- a/lib/mcp/client/oauth/flow.rb
+++ b/lib/mcp/client/oauth/flow.rb
@@ -74,12 +74,14 @@ module MCP
           )
 
           @provider.redirect_handler.call(authorization_url)
-          code, returned_state = Array(@provider.callback_handler.call)
+          code, returned_state, returned_iss = Array(@provider.callback_handler.call)
           raise AuthorizationError, "Authorization callback did not return an authorization code." unless code
 
           unless states_match?(returned_state, state)
             raise AuthorizationError, "OAuth state mismatch (CSRF protection)."
           end
+
+          ensure_authorization_response_issuer_matches!(as_metadata: as_metadata, returned: returned_iss)
 
           tokens = exchange_authorization_code(
             as_metadata: as_metadata,
@@ -408,6 +410,26 @@ module MCP
 
           raise AuthorizationError,
             "Authorization server metadata `issuer` does not match the discovery URL " \
+              "(expected #{expected.inspect}, got #{returned.inspect})."
+        end
+
+        # SEP-2468 / RFC 9207: bind the authorization response to the AS identity.
+        # The callback handler owns redirect parsing, so `returned` is expected to
+        # be the URL-form-decoded `iss` value from the authorization response.
+        def ensure_authorization_response_issuer_matches!(as_metadata:, returned:)
+          if as_metadata["authorization_response_iss_parameter_supported"] == true && returned.nil?
+            raise AuthorizationError,
+              "Authorization server advertises authorization_response_iss_parameter_supported " \
+                "but no `iss` parameter was received."
+          end
+
+          return if returned.nil?
+
+          expected = as_metadata["issuer"]
+          return if expected.to_s == returned.to_s
+
+          raise AuthorizationError,
+            "Authorization response `iss` does not match the expected issuer " \
               "(expected #{expected.inspect}, got #{returned.inspect})."
         end
 

--- a/lib/mcp/client/oauth/provider.rb
+++ b/lib/mcp/client/oauth/provider.rb
@@ -21,8 +21,9 @@ module MCP
       # - `redirect_handler` - Callable invoked with the fully-built authorization
       #   URL (a `URI`). Implementations typically open the user's browser.
       # - `callback_handler` - Callable invoked after `redirect_handler`. Returns
-      #   `[code, state]` where `code` is the authorization code and `state` is
-      #   the `state` parameter received on the redirect URI.
+      #   `[code, state]` or `[code, state, iss]` where `code` is the authorization
+      #   code, `state` is the `state` parameter, and `iss` is the optional,
+      #   URL-form-decoded RFC 9207 issuer parameter received on the redirect URI.
       #
       # Optional keyword arguments:
       # - `scope`   - String of space-separated scopes to request when the server's

--- a/test/mcp/client/oauth/flow_test.rb
+++ b/test/mcp/client/oauth/flow_test.rb
@@ -76,6 +76,23 @@ module MCP
           )
         end
 
+        def authorization_response_iss_provider(iss)
+          state_holder = {}
+          Provider.new(
+            client_metadata: {
+              redirect_uris: ["http://localhost:0/callback"],
+              grant_types: ["authorization_code"],
+              response_types: ["code"],
+              token_endpoint_auth_method: "none",
+            },
+            redirect_uri: "http://localhost:0/callback",
+            redirect_handler: ->(url) {
+              state_holder[:state] = URI.decode_www_form(url.query).to_h.fetch("state")
+            },
+            callback_handler: -> { ["test-auth-code", state_holder[:state], iss] },
+          )
+        end
+
         # Runs the full authorization flow and returns the `scope` query parameter
         # sent on the authorization request. The caller stubs the AS metadata;
         # this helper supplies a provider whose `grant_types` and optional pre-set
@@ -1530,6 +1547,74 @@ module MCP
           end
 
           assert_match(/issuer/i, error.message)
+        end
+
+        def test_run_accepts_matching_authorization_response_iss
+          stub_request(:get, @as_metadata_url).to_return(
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: JSON.generate(
+              issuer: @auth_base,
+              authorization_endpoint: "#{@auth_base}/authorize",
+              token_endpoint: "#{@auth_base}/token",
+              registration_endpoint: "#{@auth_base}/register",
+              code_challenge_methods_supported: ["S256"],
+              token_endpoint_auth_methods_supported: ["none"],
+              authorization_response_iss_parameter_supported: true,
+            ),
+          )
+
+          provider = authorization_response_iss_provider(@auth_base)
+
+          result = Flow.new(provider: provider).run!(server_url: @server_url, resource_metadata_url: @prm_url)
+
+          assert_equal(:authorized, result)
+          assert_equal("test-token-from-flow", provider.access_token)
+        end
+
+        def test_run_requires_authorization_response_iss_when_advertised
+          stub_request(:get, @as_metadata_url).to_return(
+            status: 200,
+            headers: { "Content-Type" => "application/json" },
+            body: JSON.generate(
+              issuer: @auth_base,
+              authorization_endpoint: "#{@auth_base}/authorize",
+              token_endpoint: "#{@auth_base}/token",
+              registration_endpoint: "#{@auth_base}/register",
+              code_challenge_methods_supported: ["S256"],
+              token_endpoint_auth_methods_supported: ["none"],
+              authorization_response_iss_parameter_supported: true,
+            ),
+          )
+
+          provider = authorization_response_iss_provider(nil)
+
+          error = assert_raises(Flow::AuthorizationError) do
+            Flow.new(provider: provider).run!(server_url: @server_url, resource_metadata_url: @prm_url)
+          end
+
+          assert_match(/iss/i, error.message)
+          assert_not_requested(:post, "#{@auth_base}/token")
+        end
+
+        def test_run_accepts_matching_authorization_response_iss_without_advertisement
+          provider = authorization_response_iss_provider(@auth_base)
+
+          result = Flow.new(provider: provider).run!(server_url: @server_url, resource_metadata_url: @prm_url)
+
+          assert_equal(:authorized, result)
+          assert_equal("test-token-from-flow", provider.access_token)
+        end
+
+        def test_run_rejects_authorization_response_iss_mismatch
+          provider = authorization_response_iss_provider("https://attacker.example.com")
+
+          error = assert_raises(Flow::AuthorizationError) do
+            Flow.new(provider: provider).run!(server_url: @server_url, resource_metadata_url: @prm_url)
+          end
+
+          assert_match(/iss.*does not match/i, error.message)
+          assert_not_requested(:post, "#{@auth_base}/token")
         end
 
         def test_run_rejects_non_https_authorization_server


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

Closes https://github.com/modelcontextprotocol/ruby-sdk/issues/386

Implement RFC 9207 iss validation for OAuth authorization callbacks. The provider callback remains backward-compatible with [code, state] and may return a URL-form-decoded iss value as a third element.

Per SEP-2468's RFC 9207 local-policy decision, an advertised authorization_response_iss_parameter_supported flag makes iss mandatory, while any returned iss is compared to the validated authorization server metadata issuer before token exchange.

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

SEP-2468 adds MCP guidance for RFC 9207 issuer binding in OAuth authorization responses to mitigate mix-up attacks. This SDK already validates the authorization server metadata issuer per RFC 8414 before redirecting; this change also binds the authorization callback response to that validated issuer before exchanging an authorization code.

The provider callback remains backward-compatible with `[code, state]` and may return `[code, state, iss]`. Because the SDK callback contract delegates redirect parsing to the caller, the returned `iss` is expected to be the URL-form-decoded RFC 9207 query value.

Implementation decisions:

- A returned `iss` is always compared to the validated authorization server metadata `issuer` using simple string comparison, with no URI normalization.
- Missing `iss` is rejected only when authorization server metadata advertises `authorization_response_iss_parameter_supported: true`.
- When that flag is absent or false, a missing `iss` preserves existing behavior; a present `iss` is still compared per SEP-2468's RFC 9207 local-policy decision.

This also adds a self-contained WebMock example that exercises the advertised, unadvertised, missing, and mismatched `iss` cases without contacting real servers.

Refs modelcontextprotocol/ruby-sdk#386

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

- `rake test`
- `rake rubocop`

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

None for authorization servers that do not advertise RFC 9207 authorization response issuer support and do not return `iss`.

For servers that advertise `authorization_response_iss_parameter_supported: true`, host applications must pass the callback's decoded `iss` query value through the provider callback. Missing or mismatched issuers are rejected before token exchange.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
