### PR TITLE
[Doc] Use registered callable names in examples/README.md

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -55,9 +55,9 @@ $ ruby examples/http_server.rb
 The server will start on `http://localhost:9292` and provide:
 
 - **Tools**:
-  - `ExampleTool` - adds two numbers
+  - `example_tool` - adds two numbers
   - `echo` - echoes back messages
-- **Prompts**: `ExamplePrompt` - echoes back arguments as a prompt
+- **Prompts**: `example_prompt` - echoes back arguments as a prompt
 - **Resources**: `test_resource` - returns example content
 
 ### 4. HTTP Client Example (`http_client.rb`)
@@ -98,7 +98,7 @@ A specialized HTTP server designed to test and demonstrate Server-Sent Events (S
 
 **Available Tools:**
 
-- `NotificationTool` - Send custom SSE notifications with optional delays
+- `notification_tool` - Send custom SSE notifications with optional delays
 - `echo` - Simple echo tool for basic testing
 
 **Usage:**
@@ -237,5 +237,5 @@ Call a tool:
 ```console
 curl -i http://localhost:9292 \
   -H "Mcp-Session-Id: YOUR_SESSION_ID" \
-  --json '{"jsonrpc":"2.0","method":"tools/call","id":3,"params":{"name":"ExampleTool","arguments":{"a":5,"b":3}}}'
+  --json '{"jsonrpc":"2.0","method":"tools/call","id":3,"params":{"name":"example_tool","arguments":{"a":5,"b":3}}}'
 ```


### PR DESCRIPTION
## Motivation and Context

The `tools/call` cURL example in `examples/README.md` uses `"name": "ExampleTool"`, but a tool registered by class without an explicit `tool_name` gets a snake_case name derived from its class name (via [`StringUtils.handle_from_class_name`](https://github.com/modelcontextprotocol/ruby-sdk/blob/main/lib/mcp/string_utils.rb)), so the example fails with `Tool not found: ExampleTool`. The Tools/Prompts lists in the same file had the same mismatch (`ExampleTool`, `ExamplePrompt`, `NotificationTool`). All entries now use the registered callable names.

## How Has This Been Tested?

Ran `ruby examples/http_server.rb` locally and exercised the cURL flow against it (SSE event payloads shown without the `data:` prefix):

```
## tools/list
{"jsonrpc":"2.0","id":2,"result":{"tools":[{"name":"example_tool",...},{"name":"echo",...}]}}

## tools/call with "name":"ExampleTool" (before)
{"jsonrpc":"2.0","id":3,"error":{"code":-32602,"message":"Invalid params","data":"Tool not found: ExampleTool"}}

## tools/call with "name":"example_tool" (after)
{"jsonrpc":"2.0","id":4,"result":{"content":[{"type":"text","text":"The sum of 5 and 3 is 8"}],"isError":false}}

## prompts/list
{"jsonrpc":"2.0","id":5,"result":{"prompts":[{"name":"example_prompt",...}]}}
```

The full unit suite and RuboCop pass locally.

## Breaking Changes

None (documentation only).

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added or updated documentation as needed
