### PR TITLE
Expose server tool annotations on MCP::Client::Tool

### DIFF
--- a/lib/mcp/client.rb
+++ b/lib/mcp/client.rb
@@ -131,6 +131,7 @@ module MCP
           description: tool["description"],
           input_schema: tool["inputSchema"],
           output_schema: tool["outputSchema"],
+          annotations: tool["annotations"],
         )
       end
 

--- a/lib/mcp/client/tool.rb
+++ b/lib/mcp/client/tool.rb
@@ -3,13 +3,14 @@
 module MCP
   class Client
     class Tool
-      attr_reader :name, :description, :input_schema, :output_schema
+      attr_reader :name, :description, :input_schema, :output_schema, :annotations
 
-      def initialize(name:, description:, input_schema:, output_schema: nil)
+      def initialize(name:, description:, input_schema:, output_schema: nil, annotations: nil)
         @name = name
         @description = description
         @input_schema = input_schema
         @output_schema = output_schema
+        @annotations = annotations
       end
     end
   end

--- a/test/mcp/client/tool_test.rb
+++ b/test/mcp/client/tool_test.rb
@@ -33,6 +33,24 @@ module MCP
         assert_nil(@tool.output_schema)
       end
 
+      def test_annotations_returns_nil_when_not_provided
+        assert_nil(@tool.annotations)
+      end
+
+      def test_annotations_returns_annotations_when_provided
+        tool_with_annotations = Tool.new(
+          name: "test_tool_with_annotations",
+          description: "A test tool with annotations",
+          input_schema: { "type" => "object" },
+          annotations: { "readOnlyHint" => true, "title" => "Test Tool" },
+        )
+
+        assert_equal(
+          { "readOnlyHint" => true, "title" => "Test Tool" },
+          tool_with_annotations.annotations,
+        )
+      end
+
       def test_output_schema_returns_output_schema_when_provided
         tool_with_output = Tool.new(
           name: "test_tool_with_output",
@@ -53,12 +71,14 @@ module MCP
           description: "A tool with all parameters",
           input_schema: { "type" => "object" },
           output_schema: { "type" => "object", "properties" => { "status" => { "type" => "boolean" } } },
+          annotations: { "readOnlyHint" => true },
         )
 
         assert_equal("full_tool", tool.name)
         assert_equal("A tool with all parameters", tool.description)
         assert_equal({ "type" => "object" }, tool.input_schema)
         assert_equal({ "type" => "object", "properties" => { "status" => { "type" => "boolean" } } }, tool.output_schema)
+        assert_equal({ "readOnlyHint" => true }, tool.annotations)
       end
     end
   end

--- a/test/mcp/client_test.rb
+++ b/test/mcp/client_test.rb
@@ -86,6 +86,7 @@ module MCP
               "description" => "tool1",
               "inputSchema" => {},
               "outputSchema" => { "type" => "object", "properties" => { "result" => { "type" => "string" } } },
+              "annotations" => { "readOnlyHint" => true, "title" => "Tool One" },
             },
             { "name" => "tool2", "description" => "tool2", "inputSchema" => {} },
           ],
@@ -103,8 +104,10 @@ module MCP
       assert_equal(2, tools.size)
       assert_equal("tool1", tools.first.name)
       assert_equal({ "type" => "object", "properties" => { "result" => { "type" => "string" } } }, tools.first.output_schema)
+      assert_equal({ "readOnlyHint" => true, "title" => "Tool One" }, tools.first.annotations)
       assert_equal("tool2", tools.last.name)
       assert_nil(tools.last.output_schema)
+      assert_nil(tools.last.annotations)
     end
 
     def test_tools_returns_empty_array_when_no_tools


### PR DESCRIPTION
Fixes #446

## Summary
`Client#tools` / `Client#list_tools` silently drop the server's `annotations`
field when building `MCP::Client::Tool` objects, even though the server sends
it in every `tools/list` response (`Tool#as_json` includes
`annotations: annotations_value&.to_h`). Callers have no way to read a tool's
`readOnlyHint` / `destructiveHint` / `title` / etc. from the client side today
— they have to bypass the public API and re-page `tools/list` via the private
`#request` method just to get at the raw definition.

## Change
- `MCP::Client::Tool` gains an `annotations` reader, populated the same way as
  the existing `output_schema` (optional kwarg, raw hash passed through as
  received on the wire — no reshaping into `MCP::Tool::Annotations`, since
  that class's constructor expects snake_case keys and the wire format is
  camelCase).
- `Client#list_tools` passes `annotations: tool["annotations"]` through when
  constructing each `Tool`.

## Test plan
- Added/updated unit tests in `test/mcp/client/tool_test.rb` and
  `test/mcp/client_test.rb` covering: annotations present, annotations absent
  (nil), and the full-parameters constructor case.
- `bundle exec rake test` — 1270 runs, 0 failures.
- `bundle exec rubocop` — no offenses on changed files.