### PR TITLE
Validate Required Params for `initialize` and `resources/subscribe`

### DIFF
--- a/lib/mcp/server.rb
+++ b/lib/mcp/server.rb
@@ -531,6 +531,7 @@ module MCP
           when Methods::RESOURCES_READ
             build_read_resource_result(read_resource_contents(params, session: session, related_request_id: related_request_id, cancellation: cancellation))
           when Methods::RESOURCES_SUBSCRIBE, Methods::RESOURCES_UNSUBSCRIBE
+            validate_resource_subscription_params!(params)
             dispatch_optional_context_handler(@handlers[method], params, session: session, related_request_id: related_request_id, cancellation: cancellation)
             {}
           when Methods::TOOLS_CALL
@@ -605,6 +606,8 @@ module MCP
     end
 
     def init(params, session: nil)
+      validate_initialize_params!(params)
+
       # MCP spec: the initialization phase MUST be the first interaction between client and server.
       # Reject duplicate `initialize` on an already-initialized session so the negotiated
       # client identity and capabilities cannot be silently overwritten.
@@ -612,15 +615,13 @@ module MCP
         raise RequestHandlerError.new("Invalid Request: Server already initialized", params, error_type: :invalid_request)
       end
 
-      if params
-        if session
-          session.store_client_info(client: params[:clientInfo], capabilities: params[:capabilities])
-        else
-          @client = params[:clientInfo]
-          @client_capabilities = params[:capabilities]
-        end
-        protocol_version = params[:protocolVersion]
+      if session
+        session.store_client_info(client: params[:clientInfo], capabilities: params[:capabilities])
+      else
+        @client = params[:clientInfo]
+        @client_capabilities = params[:capabilities]
       end
+      protocol_version = params[:protocolVersion]
 
       negotiated_version = if Configuration::SUPPORTED_STABLE_PROTOCOL_VERSIONS.include?(protocol_version)
         protocol_version
@@ -647,6 +648,31 @@ module MCP
         serverInfo: info,
         instructions: response_instructions,
       }.compact
+    end
+
+    def validate_resource_subscription_params!(params)
+      unless params.is_a?(Hash) && params[:uri].is_a?(String)
+        raise RequestHandlerError.new("Missing or invalid uri", params, error_type: :invalid_params)
+      end
+    end
+
+    def validate_initialize_params!(params)
+      unless params.is_a?(Hash)
+        raise RequestHandlerError.new("Invalid params", params, error_type: :invalid_params)
+      end
+
+      unless params[:protocolVersion].is_a?(String)
+        raise RequestHandlerError.new("Missing or invalid protocolVersion", params, error_type: :invalid_params)
+      end
+
+      unless params[:capabilities].is_a?(Hash)
+        raise RequestHandlerError.new("Missing or invalid capabilities", params, error_type: :invalid_params)
+      end
+
+      client_info = params[:clientInfo]
+      if !client_info.is_a?(Hash) || client_info[:name].nil? || client_info[:version].nil?
+        raise RequestHandlerError.new("Missing or invalid clientInfo", params, error_type: :invalid_params)
+      end
     end
 
     # Handles `server/discover` (MCP 2026-07-28 draft, SEP-2575): sessionless capability discovery.

--- a/test/initialize_params_test_helper.rb
+++ b/test/initialize_params_test_helper.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module InitializeParamsTestHelper
+  # `initialize` params satisfying the fields required by the MCP schema
+  # (protocolVersion, capabilities, and clientInfo).
+  def initialize_params(**overrides)
+    {
+      protocolVersion: MCP::Configuration::LATEST_STABLE_PROTOCOL_VERSION,
+      capabilities: {},
+      clientInfo: { name: "test-client", version: "1.0.0" },
+    }.merge(overrides)
+  end
+end

--- a/test/mcp/server/transports/stdio_transport_test.rb
+++ b/test/mcp/server/transports/stdio_transport_test.rb
@@ -108,6 +108,7 @@ module MCP
             id: "1",
             params: {
               protocolVersion: "2025-11-25",
+              capabilities: {},
               clientInfo: { name: "stdio-client", version: "1.0" },
             },
           }
@@ -140,6 +141,7 @@ module MCP
             id: "first",
             params: {
               protocolVersion: "2025-11-25",
+              capabilities: {},
               clientInfo: { name: "original", version: "1.0" },
             },
           }
@@ -149,6 +151,7 @@ module MCP
             id: "second",
             params: {
               protocolVersion: "2024-11-05",
+              capabilities: {},
               clientInfo: { name: "intruder", version: "9.9" },
             },
           }

--- a/test/mcp/server/transports/streamable_http_notification_integration_test.rb
+++ b/test/mcp/server/transports/streamable_http_notification_integration_test.rb
@@ -7,6 +7,8 @@ module MCP
   class Server
     module Transports
       class StreamableHTTPNotificationIntegrationTest < ActiveSupport::TestCase
+        include InitializeParamsTestHelper
+
         setup do
           @server = Server.new(
             name: "test_server",
@@ -23,7 +25,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "init" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "init", params: initialize_params }.to_json,
           )
           init_response = @transport.handle_request(init_request)
           session_id = init_response[1]["Mcp-Session-Id"]
@@ -72,7 +74,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "123" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "123", params: initialize_params }.to_json,
           )
           init_response1 = @transport.handle_request(init_request1)
           session_id1 = init_response1[1]["Mcp-Session-Id"]
@@ -81,7 +83,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "456" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "456", params: initialize_params }.to_json,
           )
           init_response2 = @transport.handle_request(init_request2)
           session_id2 = init_response2[1]["Mcp-Session-Id"]
@@ -127,7 +129,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "init" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "init", params: initialize_params }.to_json,
           )
           init_response = @transport.handle_request(init_request)
           session_id = init_response[1]["Mcp-Session-Id"]
@@ -163,7 +165,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "init" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "init", params: initialize_params }.to_json,
           )
           init_response = @transport.handle_request(init_request)
           session_id = init_response[1]["Mcp-Session-Id"]
@@ -207,7 +209,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "init" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "init", params: initialize_params }.to_json,
           )
           init_response = @transport.handle_request(init_request)
           session_id = init_response[1]["Mcp-Session-Id"]

--- a/test/mcp/server/transports/streamable_http_transport_test.rb
+++ b/test/mcp/server/transports/streamable_http_transport_test.rb
@@ -7,6 +7,8 @@ module MCP
   class Server
     module Transports
       class StreamableHTTPTransportTest < ActiveSupport::TestCase
+        include InitializeParamsTestHelper
+
         # A stream that buffers writes and remains readable after close.
         class TestStream
           def initialize
@@ -52,7 +54,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "init" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "init", params: initialize_params }.to_json,
           )
           init_response = @transport.handle_request(init_request)
           session_id = init_response[1]["Mcp-Session-Id"]
@@ -85,7 +87,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "init" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "init", params: initialize_params }.to_json,
           )
           init_response = @transport.handle_request(init_request)
           session_id = init_response[1]["Mcp-Session-Id"]
@@ -136,7 +138,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "init" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "init", params: initialize_params }.to_json,
           )
           init_response = @transport.handle_request(init_request)
           session_id = init_response[1]["Mcp-Session-Id"]
@@ -164,7 +166,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "init" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "init", params: initialize_params }.to_json,
           )
           init_response = @transport.handle_request(init_request)
           session_id = init_response[1]["Mcp-Session-Id"]
@@ -192,7 +194,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "123" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "123", params: initialize_params }.to_json,
           )
 
           response = @transport.handle_request(request)
@@ -211,7 +213,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "first" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "first", params: initialize_params }.to_json,
           )
           init_response = @transport.handle_request(init_request)
           session_id = init_response[1]["Mcp-Session-Id"]
@@ -221,7 +223,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json", "HTTP_MCP_SESSION_ID" => session_id },
-            { jsonrpc: "2.0", method: "initialize", id: "second" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "second", params: initialize_params }.to_json,
           )
           duplicate_response = @transport.handle_request(duplicate_request)
 
@@ -248,7 +250,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json", "HTTP_MCP_SESSION_ID" => "unknown-session" },
-            { jsonrpc: "2.0", method: "initialize", id: "1" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "1", params: initialize_params }.to_json,
           )
 
           response = @transport.handle_request(request)
@@ -267,7 +269,7 @@ module MCP
               "POST",
               "/",
               { "CONTENT_TYPE" => "application/json" },
-              { jsonrpc: "2.0", method: "initialize", id: "first" }.to_json,
+              { jsonrpc: "2.0", method: "initialize", id: "first", params: initialize_params }.to_json,
             )
             init_response = transport.handle_request(init_request)
             session_id = init_response[1]["Mcp-Session-Id"]
@@ -279,7 +281,7 @@ module MCP
               "POST",
               "/",
               { "CONTENT_TYPE" => "application/json", "HTTP_MCP_SESSION_ID" => session_id },
-              { jsonrpc: "2.0", method: "initialize", id: "second" }.to_json,
+              { jsonrpc: "2.0", method: "initialize", id: "second", params: initialize_params }.to_json,
             )
             duplicate_response = transport.handle_request(duplicate_request)
 
@@ -318,7 +320,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            [{ jsonrpc: "2.0", method: "initialize", id: "batched" }].to_json,
+            [{ jsonrpc: "2.0", method: "initialize", id: "batched", params: initialize_params }].to_json,
           )
 
           response = @transport.handle_request(request)
@@ -336,7 +338,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "123" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "123", params: initialize_params }.to_json,
           )
           init_response = @transport.handle_request(init_request)
           session_id = init_response[1]["Mcp-Session-Id"]
@@ -361,7 +363,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "123" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "123", params: initialize_params }.to_json,
           )
           init_response = @transport.handle_request(init_request)
           session_id = init_response[1]["Mcp-Session-Id"]
@@ -399,7 +401,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "123" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "123", params: initialize_params }.to_json,
           )
           init_response = @transport.handle_request(init_request)
           session_id = init_response[1]["Mcp-Session-Id"]
@@ -443,7 +445,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "123" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "123", params: initialize_params }.to_json,
           )
           init_response = @transport.handle_request(init_request)
           session_id = init_response[1]["Mcp-Session-Id"]
@@ -592,7 +594,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "init" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "init", params: initialize_params }.to_json,
           )
           init_response = @transport.handle_request(init_request)
           session_id = init_response[1]["Mcp-Session-Id"]
@@ -625,7 +627,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "init" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "init", params: initialize_params }.to_json,
           )
           init_response = @transport.handle_request(init_request)
           session_id = init_response[1]["Mcp-Session-Id"]
@@ -686,7 +688,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "123" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "123", params: initialize_params }.to_json,
           )
           init_response = @transport.handle_request(init_request)
           session_id = init_response[1]["Mcp-Session-Id"]
@@ -726,7 +728,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "init" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "init", params: initialize_params }.to_json,
           )
           init_response = @transport.handle_request(init_request)
           session_id = init_response[1]["Mcp-Session-Id"]
@@ -759,7 +761,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "init" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "init", params: initialize_params }.to_json,
           )
           init_response = @transport.handle_request(init_request)
           session_id = init_response[1]["Mcp-Session-Id"]
@@ -805,7 +807,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "123" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "123", params: initialize_params }.to_json,
           )
           init_response = @transport.handle_request(init_request)
           session_id = init_response[1]["Mcp-Session-Id"]
@@ -841,7 +843,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "init" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "init", params: initialize_params }.to_json,
           )
           init_response = @transport.handle_request(init_request)
           session_id = init_response[1]["Mcp-Session-Id"]
@@ -873,7 +875,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "init" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "init", params: initialize_params }.to_json,
           )
           @transport.handle_request(init_request)
 
@@ -890,7 +892,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "123" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "123", params: initialize_params }.to_json,
           )
           init_response1 = @transport.handle_request(init_request1)
           session_id1 = init_response1[1]["Mcp-Session-Id"]
@@ -900,7 +902,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "456" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "456", params: initialize_params }.to_json,
           )
           init_response2 = @transport.handle_request(init_request2)
           session_id2 = init_response2[1]["Mcp-Session-Id"]
@@ -993,7 +995,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "123" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "123", params: initialize_params }.to_json,
           )
           init_response = @transport.handle_request(init_request)
           session_id = init_response[1]["Mcp-Session-Id"]
@@ -1029,7 +1031,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "123" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "123", params: initialize_params }.to_json,
           )
           init_response1 = @transport.handle_request(init_request1)
           session_id1 = init_response1[1]["Mcp-Session-Id"]
@@ -1038,7 +1040,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "456" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "456", params: initialize_params }.to_json,
           )
           init_response2 = @transport.handle_request(init_request2)
           session_id2 = init_response2[1]["Mcp-Session-Id"]
@@ -1093,7 +1095,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "123" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "123", params: initialize_params }.to_json,
           )
           init_response = @transport.handle_request(init_request)
           session_id = init_response[1]["Mcp-Session-Id"]
@@ -1130,7 +1132,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "123" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "123", params: initialize_params }.to_json,
           )
           init_response = @transport.handle_request(init_request)
           session_id = init_response[1]["Mcp-Session-Id"]
@@ -1167,7 +1169,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "123" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "123", params: initialize_params }.to_json,
           )
           init_response = @transport.handle_request(init_request)
           session_id = init_response[1]["Mcp-Session-Id"]
@@ -1198,7 +1200,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "init" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "init", params: initialize_params }.to_json,
           )
           init_response = @transport.handle_request(init_request)
           session_id = init_response[1]["Mcp-Session-Id"]
@@ -1237,7 +1239,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "init" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "init", params: initialize_params }.to_json,
           )
           init_response = @transport.handle_request(init_request)
           session_id = init_response[1]["Mcp-Session-Id"]
@@ -1278,7 +1280,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "1" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "1", params: initialize_params }.to_json,
           )
           init_response1 = @transport.handle_request(init_request1)
           session_id1 = init_response1[1]["Mcp-Session-Id"]
@@ -1287,7 +1289,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "2" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "2", params: initialize_params }.to_json,
           )
           init_response2 = @transport.handle_request(init_request2)
           session_id2 = init_response2[1]["Mcp-Session-Id"]
@@ -1341,7 +1343,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "123" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "123", params: initialize_params }.to_json,
           )
           init_response = @transport.handle_request(init_request)
           session_id = init_response[1]["Mcp-Session-Id"]
@@ -1407,7 +1409,7 @@ module MCP
             "POST",
             "/",
             { "HTTP_ACCEPT" => "application/json, text/event-stream" },
-            { jsonrpc: "2.0", method: "initialize", id: "123" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "123", params: initialize_params }.to_json,
           )
 
           response = @transport.handle_request(request)
@@ -1428,7 +1430,7 @@ module MCP
               "CONTENT_TYPE" => "text/plain",
               "HTTP_ACCEPT" => "application/json, text/event-stream",
             },
-            { jsonrpc: "2.0", method: "initialize", id: "123" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "123", params: initialize_params }.to_json,
           )
 
           response = @transport.handle_request(request)
@@ -1443,7 +1445,7 @@ module MCP
               "CONTENT_TYPE" => "application/json; charset=utf-8",
               "HTTP_ACCEPT" => "application/json, text/event-stream",
             },
-            { jsonrpc: "2.0", method: "initialize", id: "123" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "123", params: initialize_params }.to_json,
           )
 
           response = @transport.handle_request(request)
@@ -1455,7 +1457,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "123" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "123", params: initialize_params }.to_json,
           )
 
           response = @transport.handle_request(request)
@@ -1475,7 +1477,7 @@ module MCP
               "CONTENT_TYPE" => "application/json",
               "HTTP_ACCEPT" => "application/json",
             },
-            { jsonrpc: "2.0", method: "initialize", id: "123" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "123", params: initialize_params }.to_json,
           )
 
           response = @transport.handle_request(request)
@@ -1494,7 +1496,7 @@ module MCP
               "CONTENT_TYPE" => "application/json",
               "HTTP_ACCEPT" => "text/event-stream",
             },
-            { jsonrpc: "2.0", method: "initialize", id: "123" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "123", params: initialize_params }.to_json,
           )
 
           response = @transport.handle_request(request)
@@ -1513,7 +1515,7 @@ module MCP
               "CONTENT_TYPE" => "application/json",
               "HTTP_ACCEPT" => "application/json, text/event-stream",
             },
-            { jsonrpc: "2.0", method: "initialize", id: "123" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "123", params: initialize_params }.to_json,
           )
 
           response = @transport.handle_request(request)
@@ -1528,7 +1530,7 @@ module MCP
               "CONTENT_TYPE" => "application/json",
               "HTTP_ACCEPT" => "application/json;q=0.9, text/event-stream;q=0.8",
             },
-            { jsonrpc: "2.0", method: "initialize", id: "123" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "123", params: initialize_params }.to_json,
           )
 
           response = @transport.handle_request(request)
@@ -1543,7 +1545,7 @@ module MCP
               "CONTENT_TYPE" => "application/json",
               "HTTP_ACCEPT" => "*/*",
             },
-            { jsonrpc: "2.0", method: "initialize", id: "123" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "123", params: initialize_params }.to_json,
           )
 
           response = @transport.handle_request(request)
@@ -1558,7 +1560,7 @@ module MCP
               "CONTENT_TYPE" => "application/json",
               "HTTP_ACCEPT" => "Application/JSON, Text/Event-Stream",
             },
-            { jsonrpc: "2.0", method: "initialize", id: "123" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "123", params: initialize_params }.to_json,
           )
 
           response = @transport.handle_request(request)
@@ -1570,7 +1572,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "123" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "123", params: initialize_params }.to_json,
           )
           init_response = @transport.handle_request(init_request)
           session_id = init_response[1]["Mcp-Session-Id"]
@@ -1594,7 +1596,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "123" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "123", params: initialize_params }.to_json,
           )
           init_response = @transport.handle_request(init_request)
           session_id = init_response[1]["Mcp-Session-Id"]
@@ -1620,7 +1622,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "123" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "123", params: initialize_params }.to_json,
           )
           init_response = @transport.handle_request(init_request)
           session_id = init_response[1]["Mcp-Session-Id"]
@@ -1646,7 +1648,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "123" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "123", params: initialize_params }.to_json,
           )
           init_response = @transport.handle_request(init_request)
           session_id = init_response[1]["Mcp-Session-Id"]
@@ -1670,7 +1672,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "123" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "123", params: initialize_params }.to_json,
           )
           init_response = @transport.handle_request(init_request)
           session_id = init_response[1]["Mcp-Session-Id"]
@@ -1697,7 +1699,7 @@ module MCP
               "CONTENT_TYPE" => "application/json",
               "HTTP_MCP_PROTOCOL_VERSION" => "1900-01-01",
             },
-            { jsonrpc: "2.0", method: "initialize", id: "init" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "init", params: initialize_params }.to_json,
           )
 
           response = @transport.handle_request(request)
@@ -1720,7 +1722,7 @@ module MCP
               jsonrpc: "2.0",
               method: "initialize",
               id: "init",
-              params: { protocolVersion: Configuration::LATEST_STABLE_PROTOCOL_VERSION },
+              params: initialize_params,
             }.to_json,
           )
 
@@ -1746,7 +1748,7 @@ module MCP
               jsonrpc: "2.0",
               method: "initialize",
               id: "init",
-              params: { protocolVersion: older_version },
+              params: initialize_params(protocolVersion: older_version),
             }.to_json,
           )
 
@@ -1761,7 +1763,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "init" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "init", params: initialize_params }.to_json,
           )
           init_response = @transport.handle_request(init_request)
           session_id = init_response[1]["Mcp-Session-Id"]
@@ -1794,7 +1796,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "init" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "init", params: initialize_params }.to_json,
           )
           init_response = @transport.handle_request(init_request)
           session_id = init_response[1]["Mcp-Session-Id"]
@@ -1822,7 +1824,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "init" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "init", params: initialize_params }.to_json,
           )
           init_response = @transport.handle_request(init_request)
           session_id = init_response[1]["Mcp-Session-Id"]
@@ -1847,7 +1849,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "init" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "init", params: initialize_params }.to_json,
           )
           init_response = @transport.handle_request(init_request)
           session_id = init_response[1]["Mcp-Session-Id"]
@@ -1887,7 +1889,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "init" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "init", params: initialize_params }.to_json,
           )
           init_response = @transport.handle_request(init_request)
           session_id = init_response[1]["Mcp-Session-Id"]
@@ -1915,7 +1917,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "init" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "init", params: initialize_params }.to_json,
           )
           init_response = @transport.handle_request(init_request)
           session_id = init_response[1]["Mcp-Session-Id"]
@@ -1943,7 +1945,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "init" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "init", params: initialize_params }.to_json,
           )
           init_response = @transport.handle_request(init_request)
           session_id = init_response[1]["Mcp-Session-Id"]
@@ -1969,7 +1971,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "init" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "init", params: initialize_params }.to_json,
           )
           init_response = @transport.handle_request(init_request)
           session_id = init_response[1]["Mcp-Session-Id"]
@@ -1989,7 +1991,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "init" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "init", params: initialize_params }.to_json,
           )
           init_response = @transport.handle_request(init_request)
           session_id = init_response[1]["Mcp-Session-Id"]
@@ -2044,7 +2046,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "init" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "init", params: initialize_params }.to_json,
           )
           init_response = stateless_transport.handle_request(init_request)
           assert_nil init_response[1]["Mcp-Session-Id"]
@@ -2180,10 +2182,7 @@ module MCP
                 jsonrpc: "2.0",
                 method: "initialize",
                 id: i + 1,
-                params: {
-                  protocolVersion: "2025-11-25",
-                  clientInfo: { name: "client-#{i}", version: "1.0" },
-                },
+                params: initialize_params(clientInfo: { name: "client-#{i}", version: "1.0" }),
               }.to_json,
             )
             response = stateless_transport.handle_request(request)
@@ -2249,7 +2248,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "123" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "123", params: initialize_params }.to_json,
           )
           init_response = @transport.handle_request(init_request)
           session_id = init_response[1]["Mcp-Session-Id"]
@@ -2295,7 +2294,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "init" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "init", params: initialize_params }.to_json,
           )
           init_response = transport.handle_request(init_request)
           session_id = init_response[1]["Mcp-Session-Id"]
@@ -2332,7 +2331,7 @@ module MCP
               "CONTENT_TYPE" => "application/json",
               "HTTP_ACCEPT" => "application/json",
             },
-            { jsonrpc: "2.0", method: "initialize", id: "init" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "init", params: initialize_params }.to_json,
           )
 
           response = transport.handle_request(request)
@@ -2350,7 +2349,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "init" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "init", params: initialize_params }.to_json,
           )
 
           response = transport.handle_request(request)
@@ -2371,7 +2370,7 @@ module MCP
               "CONTENT_TYPE" => "application/json",
               "HTTP_ACCEPT" => "*/*",
             },
-            { jsonrpc: "2.0", method: "initialize", id: "init" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "init", params: initialize_params }.to_json,
           )
 
           response = transport.handle_request(request)
@@ -2400,7 +2399,7 @@ module MCP
               jsonrpc: "2.0",
               method: "initialize",
               id: "init",
-              params: { protocolVersion: "2025-11-25", clientInfo: { name: "test" } },
+              params: initialize_params,
             }.to_json,
           )
           init_response = transport.handle_request(init_request)
@@ -2452,7 +2451,7 @@ module MCP
               jsonrpc: "2.0",
               method: "initialize",
               id: "init",
-              params: { protocolVersion: "2025-11-25", clientInfo: { name: "test" } },
+              params: initialize_params,
             }.to_json,
           )
           init_response = transport.handle_request(init_request)
@@ -2561,7 +2560,7 @@ module MCP
               jsonrpc: "2.0",
               method: "initialize",
               id: "init",
-              params: { protocolVersion: "2025-11-25", clientInfo: { name: "test" } },
+              params: initialize_params,
             }.to_json,
           )
           init_response = transport.handle_request(init_request)
@@ -2660,7 +2659,7 @@ module MCP
               jsonrpc: "2.0",
               method: "initialize",
               id: "init",
-              params: { protocolVersion: "2025-11-25", clientInfo: { name: "test" } },
+              params: initialize_params,
             }.to_json,
           )
           init_response = transport.handle_request(init_request)
@@ -2706,7 +2705,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "4567" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "4567", params: initialize_params }.to_json,
           )
 
           @transport.define_singleton_method(:extract_session_id) do |_request|
@@ -2756,7 +2755,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "init" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "init", params: initialize_params }.to_json,
           )
           init_response = @transport.handle_request(init_request)
           session_id = init_response[1]["Mcp-Session-Id"]
@@ -2774,7 +2773,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "init" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "init", params: initialize_params }.to_json,
           )
           init_response = @transport.handle_request(init_request)
           session_id = init_response[1]["Mcp-Session-Id"]
@@ -2842,7 +2841,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "init-a" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "init-a", params: initialize_params }.to_json,
           )
           resp_a = @transport.handle_request(init_a)
           session_a = resp_a[1]["Mcp-Session-Id"]
@@ -2851,7 +2850,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "init-b" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "init-b", params: initialize_params }.to_json,
           )
           resp_b = @transport.handle_request(init_b)
           session_b = resp_b[1]["Mcp-Session-Id"]
@@ -2913,7 +2912,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "init" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "init", params: initialize_params }.to_json,
           )
           init_response = @transport.handle_request(init_request)
           session_id = init_response[1]["Mcp-Session-Id"]
@@ -2953,7 +2952,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "init" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "init", params: initialize_params }.to_json,
           )
           init_response = @transport.handle_request(init_request)
           session_id = init_response[1]["Mcp-Session-Id"]
@@ -3021,7 +3020,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "init" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "init", params: initialize_params }.to_json,
           )
           init_response = @transport.handle_request(init_request)
           session_id = init_response[1]["Mcp-Session-Id"]
@@ -3089,7 +3088,7 @@ module MCP
               jsonrpc: "2.0",
               method: "initialize",
               id: "init",
-              params: { protocolVersion: "2025-11-25", clientInfo: { name: "test" } },
+              params: initialize_params,
             }.to_json,
           )
           init_response = transport.handle_request(init_request)
@@ -3147,7 +3146,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "init" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "init", params: initialize_params }.to_json,
           )
           init_response = @transport.handle_request(init_request)
           session_id = init_response[1]["Mcp-Session-Id"]
@@ -3206,7 +3205,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "init" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "init", params: initialize_params }.to_json,
           )
           init_response = @transport.handle_request(init_request)
           session_id = init_response[1]["Mcp-Session-Id"]
@@ -3250,7 +3249,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "init" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "init", params: initialize_params }.to_json,
           )
           init_response = @transport.handle_request(init_request)
           session_id = init_response[1]["Mcp-Session-Id"]
@@ -3349,7 +3348,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "init" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "init", params: initialize_params }.to_json,
           )
           init_response = @transport.handle_request(init_request)
           session_id = init_response[1]["Mcp-Session-Id"]
@@ -3435,7 +3434,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "init" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "init", params: initialize_params }.to_json,
           )
           init_response = @transport.handle_request(init_request)
           session_id = init_response[1]["Mcp-Session-Id"]
@@ -3492,7 +3491,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "init" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "init", params: initialize_params }.to_json,
           )
           init_response = @transport.handle_request(init_request)
           session_id = init_response[1]["Mcp-Session-Id"]
@@ -3545,7 +3544,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "init" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "init", params: initialize_params }.to_json,
           )
           init_response = @transport.handle_request(init_request)
           session_id = init_response[1]["Mcp-Session-Id"]
@@ -3574,7 +3573,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "123" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "123", params: initialize_params }.to_json,
           )
           init_response = transport.handle_request(init_request)
           session_id = init_response[1]["Mcp-Session-Id"]
@@ -3605,7 +3604,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "init" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "init", params: initialize_params }.to_json,
           )
           init_response = transport.handle_request(init_request)
           session_id = init_response[1]["Mcp-Session-Id"]
@@ -3639,7 +3638,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "init" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "init", params: initialize_params }.to_json,
           )
           init_response = transport.handle_request(init_request)
           session_id = init_response[1]["Mcp-Session-Id"]
@@ -3668,7 +3667,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "init" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "init", params: initialize_params }.to_json,
           )
           init_response = transport.handle_request(init_request)
           session_id = init_response[1]["Mcp-Session-Id"]
@@ -3696,7 +3695,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "init" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "init", params: initialize_params }.to_json,
           )
           init_response = transport.handle_request(init_request)
           session_id = init_response[1]["Mcp-Session-Id"]
@@ -3729,7 +3728,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "init" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "init", params: initialize_params }.to_json,
           )
           init_response = transport.handle_request(init_request)
           session_id = init_response[1]["Mcp-Session-Id"]
@@ -3760,7 +3759,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "init" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "init", params: initialize_params }.to_json,
           )
           init_response = transport.handle_request(init_request)
           session_id = init_response[1]["Mcp-Session-Id"]
@@ -3795,7 +3794,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "init" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "init", params: initialize_params }.to_json,
           )
           init_response = transport.handle_request(init_request)
           session_id = init_response[1]["Mcp-Session-Id"]
@@ -3856,7 +3855,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "init" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "init", params: initialize_params }.to_json,
           )
           # A freshly created session is well within the timeout, so normal use is unaffected.
           session_id = transport.handle_request(init_request)[1]["Mcp-Session-Id"]
@@ -3896,7 +3895,7 @@ module MCP
               "POST",
               "/",
               { "CONTENT_TYPE" => "application/json" },
-              { jsonrpc: "2.0", method: "initialize", id: "init" }.to_json,
+              { jsonrpc: "2.0", method: "initialize", id: "init", params: initialize_params }.to_json,
             )
             assert_equal(200, transport.handle_request(request)[0])
           end
@@ -3905,7 +3904,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "init" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "init", params: initialize_params }.to_json,
           )
           response = transport.handle_request(overflow)
 
@@ -3924,7 +3923,7 @@ module MCP
               "POST",
               "/",
               { "CONTENT_TYPE" => "application/json" },
-              { jsonrpc: "2.0", method: "initialize", id: "init" }.to_json,
+              { jsonrpc: "2.0", method: "initialize", id: "init", params: initialize_params }.to_json,
             ))
           end
 
@@ -3981,7 +3980,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "init" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "init", params: initialize_params }.to_json,
           )
           init_response = transport.handle_request(init_request)
           session_id = init_response[1]["Mcp-Session-Id"]
@@ -4002,7 +4001,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "init" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "init", params: initialize_params }.to_json,
           )
           init_response = transport.handle_request(init_request)
           session_id = init_response[1]["Mcp-Session-Id"]
@@ -4025,7 +4024,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "init" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "init", params: initialize_params }.to_json,
           )
           init_response = @transport.handle_request(init_request)
           session_id = init_response[1]["Mcp-Session-Id"]
@@ -4065,7 +4064,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "init" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "init", params: initialize_params }.to_json,
           )
           @transport.handle_request(init_request)
 
@@ -4121,7 +4120,7 @@ module MCP
               jsonrpc: "2.0",
               method: "initialize",
               id: "1",
-              params: { protocolVersion: "2025-11-25", clientInfo: { name: "a" } },
+              params: initialize_params(clientInfo: { name: "a", version: "1.0" }),
             }.to_json,
           )
           session1 = transport.handle_request(init1)[1]["Mcp-Session-Id"]
@@ -4134,7 +4133,7 @@ module MCP
               jsonrpc: "2.0",
               method: "initialize",
               id: "2",
-              params: { protocolVersion: "2025-11-25", clientInfo: { name: "b" } },
+              params: initialize_params(clientInfo: { name: "b", version: "1.0" }),
             }.to_json,
           )
           session2 = transport.handle_request(init2)[1]["Mcp-Session-Id"]
@@ -4197,7 +4196,7 @@ module MCP
               jsonrpc: "2.0",
               method: "initialize",
               id: "1",
-              params: { protocolVersion: "2025-11-25", clientInfo: { name: "a" } },
+              params: initialize_params(clientInfo: { name: "a", version: "1.0" }),
             }.to_json,
           )
           session1 = transport.handle_request(init1)[1]["Mcp-Session-Id"]
@@ -4210,7 +4209,7 @@ module MCP
               jsonrpc: "2.0",
               method: "initialize",
               id: "2",
-              params: { protocolVersion: "2025-11-25", clientInfo: { name: "b" } },
+              params: initialize_params(clientInfo: { name: "b", version: "1.0" }),
             }.to_json,
           )
           session2 = transport.handle_request(init2)[1]["Mcp-Session-Id"]
@@ -4271,10 +4270,7 @@ module MCP
               jsonrpc: "2.0",
               method: "initialize",
               id: "1",
-              params: {
-                protocolVersion: "2025-11-25",
-                clientInfo: { name: "alpha", version: "1.0" },
-              },
+              params: initialize_params(clientInfo: { name: "alpha", version: "1.0" }),
             }.to_json,
           )
           session1 = transport.handle_request(init1)[1]["Mcp-Session-Id"]
@@ -4288,10 +4284,7 @@ module MCP
               jsonrpc: "2.0",
               method: "initialize",
               id: "2",
-              params: {
-                protocolVersion: "2025-11-25",
-                clientInfo: { name: "beta", version: "2.0" },
-              },
+              params: initialize_params(clientInfo: { name: "beta", version: "2.0" }),
             }.to_json,
           )
           session2 = transport.handle_request(init2)[1]["Mcp-Session-Id"]
@@ -4315,7 +4308,7 @@ module MCP
               jsonrpc: "2.0",
               method: "initialize",
               id: "1",
-              params: { protocolVersion: "2025-11-25", clientInfo: { name: "a" } },
+              params: initialize_params(clientInfo: { name: "a", version: "1.0" }),
             }.to_json,
           )
           session1 = transport.handle_request(init1)[1]["Mcp-Session-Id"]
@@ -4328,7 +4321,7 @@ module MCP
               jsonrpc: "2.0",
               method: "initialize",
               id: "2",
-              params: { protocolVersion: "2025-11-25", clientInfo: { name: "b" } },
+              params: initialize_params(clientInfo: { name: "b", version: "1.0" }),
             }.to_json,
           )
           session2 = transport.handle_request(init2)[1]["Mcp-Session-Id"]
@@ -4378,7 +4371,7 @@ module MCP
           env = {
             "REQUEST_METHOD" => "POST",
             "PATH_INFO" => "/",
-            "rack.input" => StringIO.new({ jsonrpc: "2.0", method: "initialize", id: "init-1" }.to_json),
+            "rack.input" => StringIO.new({ jsonrpc: "2.0", method: "initialize", id: "init-1", params: initialize_params }.to_json),
             "CONTENT_TYPE" => "application/json",
             "HTTP_ACCEPT" => "application/json, text/event-stream",
           }
@@ -4407,7 +4400,7 @@ module MCP
           init_env = {
             "REQUEST_METHOD" => "POST",
             "PATH_INFO" => "/",
-            "rack.input" => StringIO.new({ jsonrpc: "2.0", method: "initialize", id: "init" }.to_json),
+            "rack.input" => StringIO.new({ jsonrpc: "2.0", method: "initialize", id: "init", params: initialize_params }.to_json),
             "CONTENT_TYPE" => "application/json",
             "HTTP_ACCEPT" => "application/json, text/event-stream",
           }
@@ -4432,7 +4425,7 @@ module MCP
           init_env = {
             "REQUEST_METHOD" => "POST",
             "PATH_INFO" => "/",
-            "rack.input" => StringIO.new({ jsonrpc: "2.0", method: "initialize", id: "init" }.to_json),
+            "rack.input" => StringIO.new({ jsonrpc: "2.0", method: "initialize", id: "init", params: initialize_params }.to_json),
             "CONTENT_TYPE" => "application/json",
             "HTTP_ACCEPT" => "application/json, text/event-stream",
           }
@@ -4458,7 +4451,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "init-frozen" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "init-frozen", params: initialize_params }.to_json,
           )
           init_response = @transport.handle_request(init_request)
           session_id = init_response[1]["Mcp-Session-Id"]
@@ -4511,7 +4504,7 @@ module MCP
 
         test "accepts a request body at the max_request_bytes boundary" do
           transport = StreamableHTTPTransport.new(@server, max_request_bytes: 4096)
-          body = { jsonrpc: "2.0", method: "initialize", id: "1" }.to_json
+          body = { jsonrpc: "2.0", method: "initialize", id: "1", params: initialize_params }.to_json
           assert_operator body.bytesize, :<=, 4096
 
           request = create_rack_request(
@@ -4609,7 +4602,7 @@ module MCP
               "CONTENT_TYPE" => "application/json",
               "HTTP_ORIGIN" => "https://app.example.com",
             },
-            { jsonrpc: "2.0", method: "initialize", id: "init" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "init", params: initialize_params }.to_json,
           )
 
           status, = transport.handle_request(request)
@@ -4625,7 +4618,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "init" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "init", params: initialize_params }.to_json,
           )
 
           status, = transport.handle_request(request)
@@ -4643,7 +4636,7 @@ module MCP
               "CONTENT_TYPE" => "application/json",
               "HTTP_ORIGIN" => "https://anywhere.example.com",
             },
-            { jsonrpc: "2.0", method: "initialize", id: "init" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "init", params: initialize_params }.to_json,
           )
 
           status, = @transport.handle_request(request)
@@ -4659,7 +4652,7 @@ module MCP
               "HTTP_HOST" => "localhost:3000",
               "HTTP_ORIGIN" => "http://localhost:3000",
             },
-            { jsonrpc: "2.0", method: "initialize", id: "init" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "init", params: initialize_params }.to_json,
           )
 
           status, = @transport.handle_request(request)
@@ -4675,7 +4668,7 @@ module MCP
               "CONTENT_TYPE" => "application/json",
               "HTTP_HOST" => "evil.example.com",
             },
-            { jsonrpc: "2.0", method: "initialize", id: "init" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "init", params: initialize_params }.to_json,
           )
 
           status, headers, body = @transport.handle_request(request)
@@ -4696,7 +4689,7 @@ module MCP
                 "CONTENT_TYPE" => "application/json",
                 "HTTP_HOST" => host,
               },
-              { jsonrpc: "2.0", method: "initialize", id: "init" }.to_json,
+              { jsonrpc: "2.0", method: "initialize", id: "init", params: initialize_params }.to_json,
             )
 
             status, = transport.handle_request(request)
@@ -4715,7 +4708,7 @@ module MCP
               "CONTENT_TYPE" => "application/json",
               "HTTP_HOST" => "LOCALHOST:3000",
             },
-            { jsonrpc: "2.0", method: "initialize", id: "init" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "init", params: initialize_params }.to_json,
           )
 
           status, = @transport.handle_request(request)
@@ -4732,7 +4725,7 @@ module MCP
               "CONTENT_TYPE" => "application/json",
               "HTTP_HOST" => "app.example.com",
             },
-            { jsonrpc: "2.0", method: "initialize", id: "init" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "init", params: initialize_params }.to_json,
           )
 
           status, = transport.handle_request(request)
@@ -4748,13 +4741,13 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json", "HTTP_HOST" => "app.example.com:8443" },
-            { jsonrpc: "2.0", method: "initialize", id: "init" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "init", params: initialize_params }.to_json,
           )
           rejected = create_rack_request(
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json", "HTTP_HOST" => "app.example.com:9000" },
-            { jsonrpc: "2.0", method: "initialize", id: "init" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "init", params: initialize_params }.to_json,
           )
 
           assert_equal(200, transport.handle_request(allowed).first)
@@ -4774,7 +4767,7 @@ module MCP
               "POST",
               "/",
               { "CONTENT_TYPE" => "application/json", "HTTP_HOST" => host, "HTTP_ORIGIN" => origin },
-              { jsonrpc: "2.0", method: "initialize", id: "init" }.to_json,
+              { jsonrpc: "2.0", method: "initialize", id: "init", params: initialize_params }.to_json,
             )
 
             assert_equal(200, transport.handle_request(request).first, "expected #{origin} / #{host} to match")
@@ -4790,7 +4783,7 @@ module MCP
               "POST",
               "/",
               { "CONTENT_TYPE" => "application/json", "HTTP_HOST" => "localhost:3000", "HTTP_ORIGIN" => origin },
-              { jsonrpc: "2.0", method: "initialize", id: "init" }.to_json,
+              { jsonrpc: "2.0", method: "initialize", id: "init", params: initialize_params }.to_json,
             )
 
             assert_equal(403, transport.handle_request(request).first, "expected #{origin} to be rejected")
@@ -4816,7 +4809,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "init" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "init", params: initialize_params }.to_json,
           )
 
           status, = @transport.handle_request(request)
@@ -4834,7 +4827,7 @@ module MCP
               "HTTP_HOST" => "evil.example.com",
               "HTTP_ORIGIN" => "https://evil.example.com",
             },
-            { jsonrpc: "2.0", method: "initialize", id: "init" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "init", params: initialize_params }.to_json,
           )
 
           status, = transport.handle_request(request)
@@ -4855,7 +4848,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json", "HTTP_ORIGIN" => "https://app.example.com" },
-            { jsonrpc: "2.0", method: "initialize", id: "init" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "init", params: initialize_params }.to_json,
           )
           session_id = transport.handle_request(init)[1]["Mcp-Session-Id"]
 
@@ -4886,7 +4879,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json", "HTTP_ORIGIN" => "https://app.example.com" },
-            { jsonrpc: "2.0", method: "initialize", id: "init" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "init", params: initialize_params }.to_json,
           )
           session_id = transport.handle_request(init)[1]["Mcp-Session-Id"]
 
@@ -4923,7 +4916,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "init" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "init", params: initialize_params }.to_json,
           )
           session_id = transport.handle_request(init)[1]["Mcp-Session-Id"]
 
@@ -4956,7 +4949,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "init" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "init", params: initialize_params }.to_json,
           )
           session_id = transport.handle_request(init)[1]["Mcp-Session-Id"]
           refute_nil(session_id)
@@ -4998,7 +4991,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: "init" }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: "init", params: initialize_params }.to_json,
           )
           session_id = transport.handle_request(init)[1]["Mcp-Session-Id"]
 

--- a/test/mcp/server_roots_test.rb
+++ b/test/mcp/server_roots_test.rb
@@ -87,9 +87,9 @@ module MCP
       assert_equal({ roots: { listChanged: true } }, server.client_capabilities)
     end
 
-    test "init stores nil when client sends no capabilities" do
+    test "init rejects params without capabilities and stores nothing" do
       server = Server.new(name: "test", version: "1.0")
-      server.handle({
+      response = server.handle({
         jsonrpc: "2.0",
         method: "initialize",
         id: 1,
@@ -99,6 +99,7 @@ module MCP
         },
       })
 
+      assert_equal(-32602, response[:error][:code])
       assert_nil server.client_capabilities
     end
 

--- a/test/mcp/server_test.rb
+++ b/test/mcp/server_test.rb
@@ -5,6 +5,7 @@ require "test_helper"
 module MCP
   class ServerTest < ActiveSupport::TestCase
     include InstrumentationTestHelper
+    include InitializeParamsTestHelper
     setup do
       @tool = Tool.define(
         name: "test_tool",
@@ -151,7 +152,7 @@ module MCP
       refute_predicate session, :initialized?
       # `initialize` must still succeed afterwards.
       response = @server.handle(
-        { jsonrpc: "2.0", method: "initialize", id: 2, params: { clientInfo: { name: "c", version: "1" } } },
+        { jsonrpc: "2.0", method: "initialize", id: 2, params: initialize_params },
         session: session,
       )
       refute_nil response[:result]
@@ -176,6 +177,7 @@ module MCP
         jsonrpc: "2.0",
         method: "initialize",
         id: 1,
+        params: initialize_params,
       }
 
       response = @server.handle(request)
@@ -204,7 +206,7 @@ module MCP
       }
 
       assert_equal expected_result, response
-      assert_instrumentation_data({ method: "initialize" })
+      assert_instrumentation_data({ method: "initialize", client: { name: "test-client", version: "1.0.0" } })
     end
 
     test "#handle initialize result carries declared capability extensions" do
@@ -216,7 +218,7 @@ module MCP
         },
       )
 
-      response = server.handle({ jsonrpc: "2.0", method: "initialize", id: 1 })
+      response = server.handle({ jsonrpc: "2.0", method: "initialize", id: 1, params: initialize_params })
 
       assert_equal(
         { "com.example/feature" => { enabled: true } },
@@ -230,7 +232,7 @@ module MCP
       capabilities.support_extensions("io.modelcontextprotocol/tasks" => {})
 
       server = Server.new(name: "extensions_test", capabilities: capabilities)
-      response = server.handle({ jsonrpc: "2.0", method: "initialize", id: 1 })
+      response = server.handle({ jsonrpc: "2.0", method: "initialize", id: 1, params: initialize_params })
 
       assert_equal(
         {
@@ -247,10 +249,7 @@ module MCP
         jsonrpc: "2.0",
         method: "initialize",
         id: 1,
-        params: {
-          clientInfo: { name: "test_client", version: "1.0.0" },
-          capabilities: { extensions: extensions },
-        },
+        params: initialize_params(capabilities: { extensions: extensions }),
       }
 
       @server.handle(request)
@@ -265,10 +264,7 @@ module MCP
         jsonrpc: "2.0",
         method: "initialize",
         id: 1,
-        params: {
-          clientInfo: { name: "test_client", version: "1.0.0" },
-          capabilities: { extensions: extensions },
-        },
+        params: initialize_params(capabilities: { extensions: extensions }),
       }
 
       @server.handle(request, session: session)
@@ -282,9 +278,7 @@ module MCP
         jsonrpc: "2.0",
         method: "initialize",
         id: 1,
-        params: {
-          clientInfo: client_info,
-        },
+        params: initialize_params(clientInfo: client_info),
       }
 
       @server.handle(request)
@@ -297,9 +291,7 @@ module MCP
         jsonrpc: "2.0",
         method: "initialize",
         id: 1,
-        params: {
-          clientInfo: client_info,
-        },
+        params: initialize_params(clientInfo: client_info),
       }
       @server.handle(initialize_request)
 
@@ -319,7 +311,7 @@ module MCP
         jsonrpc: "2.0",
         method: "initialize",
         id: 1,
-        params: { clientInfo: { name: "original", version: "1.0" } },
+        params: initialize_params(clientInfo: { name: "original", version: "1.0" }),
       }
       first_response = @server.handle(first_request, session: session)
       refute_nil first_response[:result]
@@ -328,13 +320,66 @@ module MCP
         jsonrpc: "2.0",
         method: "initialize",
         id: 2,
-        params: { clientInfo: { name: "intruder", version: "9.9" }, protocolVersion: "2024-11-05" },
+        params: initialize_params(clientInfo: { name: "intruder", version: "9.9" }, protocolVersion: "2024-11-05"),
       }
       second_response = @server.handle(second_request, session: session)
 
       assert_equal JsonRpcHandler::ErrorCode::INVALID_REQUEST, second_response[:error][:code]
       assert_equal "Invalid Request", second_response[:error][:message]
       assert_equal({ name: "original", version: "1.0" }, session.client)
+    end
+
+    test "#handle initialize with empty params returns -32602 and does not initialize the session" do
+      session = ServerSession.new(server: @server, transport: mock)
+
+      response = @server.handle({ jsonrpc: "2.0", method: "initialize", id: 1, params: {} }, session: session)
+
+      assert_equal(-32602, response[:error][:code])
+      assert_equal "Invalid params", response[:error][:message]
+      refute_predicate session, :initialized?
+    end
+
+    test "#handle initialize without params returns -32602" do
+      response = @server.handle({ jsonrpc: "2.0", method: "initialize", id: 1 })
+
+      assert_equal(-32602, response[:error][:code])
+      assert_equal "Invalid params", response[:error][:message]
+    end
+
+    test "#handle initialize with a missing required field returns -32602" do
+      [:protocolVersion, :capabilities, :clientInfo].each do |field|
+        params = initialize_params.tap { |hash| hash.delete(field) }
+
+        response = @server.handle({ jsonrpc: "2.0", method: "initialize", id: 1, params: params })
+
+        assert_equal(-32602, response[:error][:code], "expected -32602 when #{field} is missing")
+        assert_includes response[:error][:data], field.to_s
+      end
+    end
+
+    test "#handle initialize with clientInfo missing name or version returns -32602" do
+      [{ name: "client-without-version" }, { version: "1.0.0" }].each do |client_info|
+        response = @server.handle({
+          jsonrpc: "2.0",
+          method: "initialize",
+          id: 1,
+          params: initialize_params(clientInfo: client_info),
+        })
+
+        assert_equal(-32602, response[:error][:code])
+        assert_includes response[:error][:data], "clientInfo"
+      end
+    end
+
+    test "#handle initialize with an unsupported protocolVersion still negotiates the fallback version" do
+      response = @server.handle({
+        jsonrpc: "2.0",
+        method: "initialize",
+        id: 1,
+        params: initialize_params(protocolVersion: "1999-01-01"),
+      })
+
+      assert_equal Configuration::LATEST_STABLE_PROTOCOL_VERSION, response[:result][:protocolVersion]
     end
 
     test "instrumentation data does not include client key when no clientInfo provided" do
@@ -1540,6 +1585,7 @@ module MCP
         jsonrpc: "2.0",
         method: "initialize",
         id: 1,
+        params: initialize_params,
       }
 
       response = @server.handle(request)
@@ -1552,6 +1598,7 @@ module MCP
         jsonrpc: "2.0",
         method: "initialize",
         id: 1,
+        params: initialize_params,
       }
 
       response = server.handle(request)
@@ -1567,6 +1614,7 @@ module MCP
         jsonrpc: "2.0",
         method: "initialize",
         id: 1,
+        params: initialize_params,
       }
 
       response = server.handle(request)
@@ -1580,6 +1628,7 @@ module MCP
         jsonrpc: "2.0",
         method: "initialize",
         id: 1,
+        params: initialize_params,
       }
       response = server.handle(request)
 
@@ -1592,6 +1641,7 @@ module MCP
         jsonrpc: "2.0",
         method: "initialize",
         id: 1,
+        params: initialize_params,
       }
       response = server.handle(request)
 
@@ -1607,6 +1657,7 @@ module MCP
         jsonrpc: "2.0",
         method: "initialize",
         id: 1,
+        params: initialize_params,
       }
       response = server.handle(request)
       expected_icons = [{ mimeType: "image/png", sizes: ["48x48"], src: "https://example.com", theme: "light" }]
@@ -1620,6 +1671,7 @@ module MCP
         jsonrpc: "2.0",
         method: "initialize",
         id: 1,
+        params: initialize_params,
       }
 
       response = server.handle(request)
@@ -1632,6 +1684,7 @@ module MCP
         jsonrpc: "2.0",
         method: "initialize",
         id: 1,
+        params: initialize_params,
       }
 
       response = server.handle(request)
@@ -1905,6 +1958,7 @@ module MCP
         jsonrpc: "2.0",
         method: "initialize",
         id: 1,
+        params: initialize_params(protocolVersion: "1999-01-01"),
       }
 
       response = server.handle(request)
@@ -1918,9 +1972,7 @@ module MCP
         jsonrpc: "2.0",
         method: "initialize",
         id: 1,
-        params: {
-          protocolVersion: "2025-06-18",
-        },
+        params: initialize_params(protocolVersion: "2025-06-18"),
       }
 
       response = server.handle(request)
@@ -1934,9 +1986,7 @@ module MCP
         jsonrpc: "2.0",
         method: "initialize",
         id: 1,
-        params: {
-          protocolVersion: "1999-01-01",
-        },
+        params: initialize_params(protocolVersion: "1999-01-01"),
       }
 
       response = server.handle(request)
@@ -1954,9 +2004,7 @@ module MCP
         jsonrpc: "2.0",
         method: "initialize",
         id: 1,
-        params: {
-          protocolVersion: "2025-06-18",
-        },
+        params: initialize_params(protocolVersion: "2025-06-18"),
       }
 
       response = server.handle(request)
@@ -1972,9 +2020,7 @@ module MCP
         jsonrpc: "2.0",
         method: "initialize",
         id: 1,
-        params: {
-          protocolVersion: "2025-03-26",
-        },
+        params: initialize_params(protocolVersion: "2025-03-26"),
       }
 
       response = server.handle(request)
@@ -1990,9 +2036,7 @@ module MCP
         jsonrpc: "2.0",
         method: "initialize",
         id: 1,
-        params: {
-          protocolVersion: "2024-11-05",
-        },
+        params: initialize_params(protocolVersion: "2024-11-05"),
       }
 
       response = server.handle(request)
@@ -2381,7 +2425,7 @@ module MCP
         capabilities: { completions: {} },
       )
 
-      server.handle({ jsonrpc: "2.0", method: "initialize", id: 1 })
+      server.handle({ jsonrpc: "2.0", method: "initialize", id: 1, params: initialize_params })
       server.handle({ jsonrpc: "2.0", method: "notifications/initialized" })
 
       response = server.handle({
@@ -2419,7 +2463,7 @@ module MCP
         { completion: { values: ["python", "pytorch", "pyside"], total: 10, hasMore: true } }
       end
 
-      server.handle({ jsonrpc: "2.0", method: "initialize", id: 1 })
+      server.handle({ jsonrpc: "2.0", method: "initialize", id: 1, params: initialize_params })
       server.handle({ jsonrpc: "2.0", method: "notifications/initialized" })
 
       response = server.handle({
@@ -2457,7 +2501,7 @@ module MCP
         { completion: { values: ["file:///src", "file:///spec"], hasMore: false } }
       end
 
-      server.handle({ jsonrpc: "2.0", method: "initialize", id: 1 })
+      server.handle({ jsonrpc: "2.0", method: "initialize", id: 1, params: initialize_params })
       server.handle({ jsonrpc: "2.0", method: "notifications/initialized" })
 
       response = server.handle({
@@ -2500,7 +2544,7 @@ module MCP
         { completion: { values: ["flask"], hasMore: false } }
       end
 
-      server.handle({ jsonrpc: "2.0", method: "initialize", id: 1 })
+      server.handle({ jsonrpc: "2.0", method: "initialize", id: 1, params: initialize_params })
       server.handle({ jsonrpc: "2.0", method: "notifications/initialized" })
 
       server.handle({
@@ -2529,7 +2573,7 @@ module MCP
         { completion: { values: (1..150).map(&:to_s), hasMore: false } }
       end
 
-      server.handle({ jsonrpc: "2.0", method: "initialize", id: 1 })
+      server.handle({ jsonrpc: "2.0", method: "initialize", id: 1, params: initialize_params })
       server.handle({ jsonrpc: "2.0", method: "notifications/initialized" })
 
       response = server.handle({
@@ -2556,7 +2600,7 @@ module MCP
         capabilities: { completions: {} },
       )
 
-      server.handle({ jsonrpc: "2.0", method: "initialize", id: 1 })
+      server.handle({ jsonrpc: "2.0", method: "initialize", id: 1, params: initialize_params })
       server.handle({ jsonrpc: "2.0", method: "notifications/initialized" })
 
       response = server.handle({
@@ -2578,7 +2622,7 @@ module MCP
         capabilities: { completions: {} },
       )
 
-      server.handle({ jsonrpc: "2.0", method: "initialize", id: 1 })
+      server.handle({ jsonrpc: "2.0", method: "initialize", id: 1, params: initialize_params })
       server.handle({ jsonrpc: "2.0", method: "notifications/initialized" })
 
       response = server.handle({
@@ -2600,7 +2644,7 @@ module MCP
         capabilities: { completions: {} },
       )
 
-      server.handle({ jsonrpc: "2.0", method: "initialize", id: 1 })
+      server.handle({ jsonrpc: "2.0", method: "initialize", id: 1, params: initialize_params })
       server.handle({ jsonrpc: "2.0", method: "notifications/initialized" })
 
       response = server.handle({
@@ -2624,7 +2668,7 @@ module MCP
         capabilities: { completions: {} },
       )
 
-      server.handle({ jsonrpc: "2.0", method: "initialize", id: 1 })
+      server.handle({ jsonrpc: "2.0", method: "initialize", id: 1, params: initialize_params })
       server.handle({ jsonrpc: "2.0", method: "notifications/initialized" })
 
       response = server.handle({
@@ -2646,7 +2690,7 @@ module MCP
         capabilities: { completions: {} },
       )
 
-      server.handle({ jsonrpc: "2.0", method: "initialize", id: 1 })
+      server.handle({ jsonrpc: "2.0", method: "initialize", id: 1, params: initialize_params })
       server.handle({ jsonrpc: "2.0", method: "notifications/initialized" })
 
       response = server.handle({
@@ -2677,7 +2721,7 @@ module MCP
         { completion: { values: ["file:///README.md"], hasMore: false } }
       end
 
-      server.handle({ jsonrpc: "2.0", method: "initialize", id: 1 })
+      server.handle({ jsonrpc: "2.0", method: "initialize", id: 1, params: initialize_params })
       server.handle({ jsonrpc: "2.0", method: "notifications/initialized" })
 
       response = server.handle({
@@ -2708,7 +2752,7 @@ module MCP
         capabilities: { completions: {} },
       )
 
-      server.handle({ jsonrpc: "2.0", method: "initialize", id: 1 })
+      server.handle({ jsonrpc: "2.0", method: "initialize", id: 1, params: initialize_params })
       server.handle({ jsonrpc: "2.0", method: "notifications/initialized" })
 
       response = server.handle({
@@ -2731,7 +2775,7 @@ module MCP
         capabilities: { completions: {} },
       )
 
-      server.handle({ jsonrpc: "2.0", method: "initialize", id: 1 })
+      server.handle({ jsonrpc: "2.0", method: "initialize", id: 1, params: initialize_params })
       server.handle({ jsonrpc: "2.0", method: "notifications/initialized" })
 
       response = server.handle({
@@ -2759,7 +2803,7 @@ module MCP
         nil
       end
 
-      server.handle({ jsonrpc: "2.0", method: "initialize", id: 1 })
+      server.handle({ jsonrpc: "2.0", method: "initialize", id: 1, params: initialize_params })
       server.handle({ jsonrpc: "2.0", method: "notifications/initialized" })
 
       response = server.handle({
@@ -2794,7 +2838,7 @@ module MCP
         { "completion" => { "values" => ["alpha", "beta"], "hasMore" => true } }
       end
 
-      server.handle({ jsonrpc: "2.0", method: "initialize", id: 1 })
+      server.handle({ jsonrpc: "2.0", method: "initialize", id: 1, params: initialize_params })
       server.handle({ jsonrpc: "2.0", method: "notifications/initialized" })
 
       response = server.handle({
@@ -2818,7 +2862,7 @@ module MCP
         capabilities: { completions: {} },
       )
 
-      server.handle({ jsonrpc: "2.0", method: "initialize", id: 1 })
+      server.handle({ jsonrpc: "2.0", method: "initialize", id: 1, params: initialize_params })
       server.handle({ jsonrpc: "2.0", method: "notifications/initialized" })
 
       response = server.handle({
@@ -2837,7 +2881,7 @@ module MCP
         prompts: [],
       )
 
-      server.handle({ jsonrpc: "2.0", method: "initialize", id: 1 })
+      server.handle({ jsonrpc: "2.0", method: "initialize", id: 1, params: initialize_params })
       server.handle({ jsonrpc: "2.0", method: "notifications/initialized" })
 
       response = server.handle({
@@ -2860,7 +2904,7 @@ module MCP
         capabilities: { resources: { subscribe: true } },
       )
 
-      server.handle({ jsonrpc: "2.0", method: "initialize", id: 1 })
+      server.handle({ jsonrpc: "2.0", method: "initialize", id: 1, params: initialize_params })
       server.handle({ jsonrpc: "2.0", method: "notifications/initialized" })
 
       response = server.handle({
@@ -2886,7 +2930,7 @@ module MCP
         capabilities: { resources: { subscribe: true } },
       )
 
-      server.handle({ jsonrpc: "2.0", method: "initialize", id: 1 })
+      server.handle({ jsonrpc: "2.0", method: "initialize", id: 1, params: initialize_params })
       server.handle({ jsonrpc: "2.0", method: "notifications/initialized" })
 
       response = server.handle({
@@ -2918,7 +2962,7 @@ module MCP
         {}
       end
 
-      server.handle({ jsonrpc: "2.0", method: "initialize", id: 1 })
+      server.handle({ jsonrpc: "2.0", method: "initialize", id: 1, params: initialize_params })
       server.handle({ jsonrpc: "2.0", method: "notifications/initialized" })
 
       response = server.handle({
@@ -2951,7 +2995,7 @@ module MCP
         {}
       end
 
-      server.handle({ jsonrpc: "2.0", method: "initialize", id: 1 })
+      server.handle({ jsonrpc: "2.0", method: "initialize", id: 1, params: initialize_params })
       server.handle({ jsonrpc: "2.0", method: "notifications/initialized" })
 
       response = server.handle({
@@ -2970,6 +3014,73 @@ module MCP
         response,
       )
       assert_equal "https://example.com/resource", received_params[:uri]
+    end
+
+    test "#handle resources/subscribe without uri returns -32602" do
+      server = Server.new(
+        name: "test_server",
+        capabilities: { resources: { subscribe: true } },
+      )
+
+      server.handle({ jsonrpc: "2.0", method: "initialize", id: 1, params: initialize_params })
+      server.handle({ jsonrpc: "2.0", method: "notifications/initialized" })
+
+      response = server.handle({
+        jsonrpc: "2.0",
+        id: 2,
+        method: "resources/subscribe",
+        params: {},
+      })
+
+      assert_equal(-32602, response[:error][:code])
+      assert_equal "Invalid params", response[:error][:message]
+      assert_includes response[:error][:data], "uri"
+    end
+
+    test "#handle resources/unsubscribe without uri returns -32602" do
+      server = Server.new(
+        name: "test_server",
+        capabilities: { resources: { subscribe: true } },
+      )
+
+      server.handle({ jsonrpc: "2.0", method: "initialize", id: 1, params: initialize_params })
+      server.handle({ jsonrpc: "2.0", method: "notifications/initialized" })
+
+      response = server.handle({
+        jsonrpc: "2.0",
+        id: 2,
+        method: "resources/unsubscribe",
+        params: {},
+      })
+
+      assert_equal(-32602, response[:error][:code])
+      assert_equal "Invalid params", response[:error][:message]
+    end
+
+    test "#handle resources/subscribe without uri does not invoke a custom handler" do
+      server = Server.new(
+        name: "test_server",
+        capabilities: { resources: { subscribe: true } },
+      )
+
+      handler_called = false
+      server.resources_subscribe_handler do |_params|
+        handler_called = true
+        {}
+      end
+
+      server.handle({ jsonrpc: "2.0", method: "initialize", id: 1, params: initialize_params })
+      server.handle({ jsonrpc: "2.0", method: "notifications/initialized" })
+
+      response = server.handle({
+        jsonrpc: "2.0",
+        id: 2,
+        method: "resources/subscribe",
+        params: {},
+      })
+
+      assert_equal(-32602, response[:error][:code])
+      refute handler_called
     end
 
     test "tools/call with no args" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -22,3 +22,4 @@ require "active_support/test_case"
 require "sorbet-runtime" if RUBY_VERSION >= "3.0"
 
 require_relative "instrumentation_test_helper"
+require_relative "initialize_params_test_helper"


### PR DESCRIPTION
## Motivation and Context

Fixes https://github.com/modelcontextprotocol/ruby-sdk/issues/450

The MCP schema requires `protocolVersion`, `capabilities`, and `clientInfo` on `initialize` params, and `uri` on `resources/subscribe` and `resources/unsubscribe` params. The server accepted requests with these fields absent: `initialize` silently negotiated the server's default protocol version, and `resources/subscribe` returned an empty success result. Both now return `-32602` Invalid params, matching the Python SDK, which rejects such requests during pydantic validation. The `uri` check runs before dispatch so it also covers handlers registered via `resources_subscribe_handler` and `resources_unsubscribe_handler`.

A `protocolVersion` value that is present but unsupported still negotiates the server's fallback version, as the spec's lifecycle section requires.

## How Has This Been Tested?

Reproduced the issue's stdio repro steps: both malformed requests now return `-32602` instead of succeeding.

## Breaking Changes

Clients that send `initialize` without `protocolVersion`, `capabilities`, or `clientInfo`, or `resources/subscribe` / `resources/unsubscribe` without `uri`, now receive `-32602` Invalid params instead of a success response. Such requests violate the MCP schema, but any code relying on the previous lenient behavior (for example, test harnesses sending bare `initialize` requests) must now include the required fields.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
