### PR TITLE
Send required `initialize` params in the mutex probe test helper

### DIFF
--- a/test/mcp/server/transports/streamable_http_transport_test.rb
+++ b/test/mcp/server/transports/streamable_http_transport_test.rb
@@ -5089,7 +5089,7 @@ module MCP
             "POST",
             "/",
             { "CONTENT_TYPE" => "application/json" },
-            { jsonrpc: "2.0", method: "initialize", id: id }.to_json,
+            { jsonrpc: "2.0", method: "initialize", id: id, params: initialize_params }.to_json,
           )
           @transport.handle_request(init_request)[1]["Mcp-Session-Id"]
         end


### PR DESCRIPTION
## Motivation and Context

`bundle exec rake` fails on main with four errors in `streamable_http_transport_test.rb`:

```
NoMethodError: undefined method '[]=' for nil
  streamable_http_transport_test.rb:5119 (install_mutex_probe_stream)
```

This is a semantic conflict between two merged PRs. #451 made the server reject `initialize` requests that lack the required `protocolVersion`, `capabilities`, and `clientInfo` params with -32602. #449, merged after but developed before it, added the "writes outside the mutex" tests, whose `initialize_test_session` helper sends an `initialize` request with no params. That request is now rejected, no session is created, so `@sessions[session_id]` is nil and installing the probe stream raises `NoMethodError`.

The fix adds `params: initialize_params` to the helper's request body, matching the pattern used by every other `initialize` request in the file via `InitializeParamsTestHelper`.

## How Has This Been Tested?

`bundle exec rake` now passes: 1318 runs, 0 failures, 0 errors, and RuboCop reports no offenses. The four previously failing tests are the regression coverage.

## Breaking Changes

None. Test-only change.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
