### PR TITLE
Reject notifications carrying an unknown or expired session

### DIFF
--- a/lib/mcp/server/transports/streamable_http_transport.rb
+++ b/lib/mcp/server/transports/streamable_http_transport.rb
@@ -517,6 +517,11 @@ module MCP
             end
 
             if notification?(body)
+              # Reject a notification carrying an unknown or expired session ID instead of
+              # dispatching it against the shared `Server`. Mirrors the response and regular-request
+              # branches; without it a custom notification handler could run without a live session.
+              return session_not_found_response if !@stateless && !session_active?(session_id)
+
               dispatch_notification(body_string, session_id)
               handle_accepted
             elsif response?(body)

--- a/test/mcp/server/transports/streamable_http_transport_test.rb
+++ b/test/mcp/server/transports/streamable_http_transport_test.rb
@@ -525,6 +525,40 @@ module MCP
           assert_equal "Missing session ID", body["error"]["message"]
         end
 
+        test "rejects notification with an unknown session ID in stateful mode" do
+          request = create_rack_request(
+            "POST",
+            "/",
+            { "CONTENT_TYPE" => "application/json", "HTTP_MCP_SESSION_ID" => "does-not-exist" },
+            { jsonrpc: "2.0", method: "notifications/initialized" }.to_json,
+          )
+
+          response = @transport.handle_request(request)
+          assert_equal 404, response[0]
+          body = JSON.parse(response[2][0])
+          assert_equal "Session not found", body["error"]["message"]
+        end
+
+        test "accepts a notification carrying a live session ID in stateful mode" do
+          init_request = create_rack_request(
+            "POST",
+            "/",
+            { "CONTENT_TYPE" => "application/json" },
+            { jsonrpc: "2.0", method: "initialize", id: "init", params: initialize_params }.to_json,
+          )
+          session_id = @transport.handle_request(init_request)[1]["Mcp-Session-Id"]
+
+          notification = create_rack_request(
+            "POST",
+            "/",
+            { "CONTENT_TYPE" => "application/json", "HTTP_MCP_SESSION_ID" => session_id },
+            { jsonrpc: "2.0", method: "notifications/initialized" }.to_json,
+          )
+
+          response = @transport.handle_request(notification)
+          assert_equal 202, response[0]
+        end
+
         test "rejects response without session ID in stateful mode" do
           request = create_rack_request(
             "POST",


### PR DESCRIPTION
## Motivation and Context

In `StreamableHTTPTransport#handle_post`, the response and regular-request branches reject a message whose session no longer exists (the response branch via `session_exists?`, the regular path via `validate_and_touch_session`), but the notification branch dispatched unconditionally. A notification carrying a present-but-unknown (or expired-but-not-yet-reaped) `Mcp-Session-Id` therefore passed the `missing_session_id` gate and the ownership gate (which returns true when the session does not exist) and reached `dispatch_notification` with no session, running against the shared `Server` instead of a live `ServerSession`. With the default no-op notification handlers this had no visible effect, but a custom notification handler would then run without a live session behind it.

`handle_post` now checks `session_active?` in the notification branch, mirroring the other two branches. `session_active?` rejects an unknown or expired session (evicting the expired one) without extending its lifetime, so a stale session ID yields `404 Session not found` and a live session is dispatched exactly as before.

## How Has This Been Tested?

New tests in `test/mcp/server/transports/streamable_http_transport_test.rb` assert that a notification with an unknown session ID is rejected with `404 Session not found` and that a notification carrying a live session ID is still accepted with `202`. The new rejection test fails against the previous code (it returned `202`) and passes now.

## Breaking Changes

None for a conforming client: a client that has completed `initialize` sends its notifications with the live session ID and is unaffected. Only a notification bearing an unknown or expired session ID, previously accepted with `202`, now receives `404 Session not found`.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
