### PR TITLE
Fix RuboCop offenses detected with rubocop-shopify 3.0.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,3 +16,7 @@ Lint/IncompatibleIoSelectWithFiberScheduler:
 
 Minitest/LiteralAsActualArgument:
   Enabled: true
+
+Naming/MethodName:
+  AllowedPatterns:
+    - '\Atest_'

--- a/lib/json_rpc_handler.rb
+++ b/lib/json_rpc_handler.rb
@@ -16,7 +16,7 @@ module JsonRpcHandler
     PARSE_ERROR = -32700
   end
 
-  DEFAULT_ALLOWED_ID_CHARACTERS = /\A[a-zA-Z0-9_-]+\z/
+  DEFAULT_ALLOWED_ID_CHARACTERS = /\A[a-zA-Z0-9_-]+\z/.freeze
 
   # Sentinel return value from a handler. When a handler returns this,
   # `process_request` emits no JSON-RPC response for the request,

--- a/lib/mcp/client/oauth/discovery.rb
+++ b/lib/mcp/client/oauth/discovery.rb
@@ -37,7 +37,7 @@ module MCP
         # Matches a single `key=value` pair inside an HTTP auth-scheme challenge.
         # `value` is either a quoted string (which can contain commas and spaces)
         # or a bare token, per RFC 7235.
-        WWW_AUTH_PARAM_PATTERN = /\A([A-Za-z0-9_-]+)\s*=\s*(?:"((?:[^"\\]|\\.)*)"|([^\s,]+))/
+        WWW_AUTH_PARAM_PATTERN = /\A([A-Za-z0-9_-]+)\s*=\s*(?:"((?:[^"\\]|\\.)*)"|([^\s,]+))/.freeze
 
         class << self
           # Parses a `WWW-Authenticate` header and returns the parameters of

--- a/lib/mcp/configuration.rb
+++ b/lib/mcp/configuration.rb
@@ -5,7 +5,7 @@ module MCP
     LATEST_STABLE_PROTOCOL_VERSION = "2025-11-25"
     SUPPORTED_STABLE_PROTOCOL_VERSIONS = [
       LATEST_STABLE_PROTOCOL_VERSION, "2025-06-18", "2025-03-26", "2024-11-05",
-    ]
+    ].freeze
     DEFAULT_NEGOTIATED_PROTOCOL_VERSION = "2025-03-26"
 
     attr_writer :exception_reporter, :around_request

--- a/lib/mcp/icon.rb
+++ b/lib/mcp/icon.rb
@@ -2,7 +2,7 @@
 
 module MCP
   class Icon
-    SUPPORTED_THEMES = ["light", "dark"]
+    SUPPORTED_THEMES = ["light", "dark"].freeze
 
     attr_reader :mime_type, :sizes, :src, :theme
 

--- a/lib/mcp/instrumentation.rb
+++ b/lib/mcp/instrumentation.rb
@@ -14,9 +14,7 @@ module MCP
       rescue => e
         already_reported = begin
           !!exception_already_reported&.call(e)
-        # rubocop:disable Lint/RescueException
         rescue Exception
-          # rubocop:enable Lint/RescueException
           # The predicate is expected to be side-effect-free and return a boolean.
           # Any exception raised from it (including non-StandardError such as SystemExit)
           # must not shadow the original exception.

--- a/lib/mcp/resource_template.rb
+++ b/lib/mcp/resource_template.rb
@@ -8,7 +8,7 @@ module MCP
       # Applied after `Regexp.escape`, which turns `{` and `}` into `\{` and `\}`.
       # Variable names are restricted to valid Regexp named-group names,
       # so RFC 6570 operator expressions (e.g. `{?query}`) stay literal and never match.
-      VARIABLE_PATTERN = /\\\{([A-Za-z_]\w*)\\\}/
+      VARIABLE_PATTERN = /\\\{([A-Za-z_]\w*)\\\}/.freeze
 
       attr_reader :uri_template_value
       attr_reader :title_value

--- a/lib/mcp/server.rb
+++ b/lib/mcp/server.rb
@@ -963,9 +963,7 @@ module MCP
     end
 
     def index_resources_by_uri(resources)
-      resources.each_with_object({}) do |resource, hash|
-        hash[resource.uri] = resource
-      end
+      resources.to_h { |resource| [resource.uri, resource] }
     end
 
     def error_tool_response(text)

--- a/test/mcp/server/transports/stdio_notification_integration_test.rb
+++ b/test/mcp/server/transports/stdio_notification_integration_test.rb
@@ -27,7 +27,7 @@ module MCP
             nil # Simulate end of input
           end
 
-          def set_encoding(encoding) # rubocop:disable Naming/AccessorMethodName
+          def set_encoding(encoding)
             # Mock implementation
           end
 

--- a/test/mcp/server/transports/streamable_http_transport_test.rb
+++ b/test/mcp/server/transports/streamable_http_transport_test.rb
@@ -1925,7 +1925,10 @@ module MCP
         end
 
         test "missing MCP-Protocol-Version header falls back to default for validation" do
-          MCP::Configuration::SUPPORTED_STABLE_PROTOCOL_VERSIONS.stubs(:include?).returns(false)
+          # The constant is frozen, so swap it out instead of stubbing `include?` on it.
+          original_versions = MCP::Configuration::SUPPORTED_STABLE_PROTOCOL_VERSIONS
+          MCP::Configuration.send(:remove_const, :SUPPORTED_STABLE_PROTOCOL_VERSIONS)
+          MCP::Configuration.const_set(:SUPPORTED_STABLE_PROTOCOL_VERSIONS, [].freeze)
 
           request = Rack::Request.new(
             "REQUEST_METHOD" => "POST",
@@ -1938,6 +1941,9 @@ module MCP
 
           body = JSON.parse(response[2][0])
           assert_includes body["error"]["message"], MCP::Configuration::DEFAULT_NEGOTIATED_PROTOCOL_VERSION
+        ensure
+          MCP::Configuration.send(:remove_const, :SUPPORTED_STABLE_PROTOCOL_VERSIONS)
+          MCP::Configuration.const_set(:SUPPORTED_STABLE_PROTOCOL_VERSIONS, original_versions)
         end
 
         test "POST request with empty MCP-Protocol-Version header returns 400" do


### PR DESCRIPTION
## Motivation and Context

This repository does not track Gemfile.lock, so `bundle install` resolves to the latest RuboCop gems. Upgrading rubocop-shopify from 2.x to 3.0.0 surfaces 8 new offenses because the shared config no longer disables `Style/MutableConstant`, newly disables `Lint/RescueException` and `Naming/AccessorMethodName`, and drops `AllowedPatterns` for `Naming/MethodName`. Upgrading rubocop itself to 1.88 surfaces one more offense from the new `Style/ReduceToHash` cop.

This change fixes them as follows:

- Freeze mutable constants. Regexp constants are also flagged because `TargetRubyVersion` is 2.7, where Regexp literals are not frozen.
- Remove inline disable directives that became redundant.
- Restore `AllowedPatterns: ['\Atest_']` for `Naming/MethodName` so `def test_` style test names can reference class names such as `NoMethodError`.
- Swap out the frozen `SUPPORTED_STABLE_PROTOCOL_VERSIONS` constant in the protocol version fallback test since Mocha cannot stub methods on frozen objects.
- Use `to_h` instead of `each_with_object` in `Server#index_resources_by_uri`.

Ref: https://rubygems.org/gems/rubocop-shopify/versions/3.0.0

## How Has This Been Tested?

`bundle exec rake` passes: 1402 runs, 0 failures, 0 errors, and RuboCop reports no offenses. The conformance suite also passes against its baseline.

## Breaking Changes

None. Freezing these constants only affects code that mutates them in place, which has never been supported.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
