### PR TITLE
Avoid cancelling in-progress conformance runs on main

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: conformance-${{ github.ref }}
+  group: conformance-${{ github.ref }}-${{ github.event_name == 'push' && github.sha || '' }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
## Motivation and Context

When two PRs are merged to main in quick succession, the Conformance Tests run for the earlier merge commit is cancelled by the run for the later one.

On push events, `github.ref` is always `refs/heads/main`, so every merge to main shares the same concurrency group and `cancel-in-progress: true` cancels all but the latest run. As a result, only the last merged PR gets a conformance result.

This change appends `github.sha` to the concurrency group for push events so that each merge commit runs independently. For pull_request events the SHA part is empty, keeping the existing behavior where pushing new commits to a PR cancels its superseded runs.

## How Has This Been Tested?

Validated the workflow YAML syntax locally. The concurrent behavior itself can only be observed on GitHub Actions, by confirming that both Conformance Tests runs complete when two pushes land on main within a short interval.

## Breaking Changes

None.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
