### PR TITLE
Add ROADMAP.md outlining the path toward SEP-1730 Tier 1

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,39 @@
+# Roadmap
+
+This roadmap outlines the MCP Ruby SDK's path toward SEP-1730 Tier 1.
+It is a living document and will evolve as the SDK matures.
+
+## Current Status
+
+The SDK implements the 2025-06-18 and 2025-11-25 spec revisions, and passes all server and client conformance scenarios.
+
+## API Stability
+
+The 1.0.0 release will mark the public API as stable: breaking changes then ship only in major releases,
+apart from the narrow exceptions documented in [VERSIONING.md](VERSIONING.md),
+which also defines the Semantic Versioning scheme and breaking-change policy.
+
+## Deprecated Features
+
+The 2026-07-28 spec revision deprecates Roots, Sampling, and Logging (SEP-2577).
+These features remain fully supported throughout 1.x, and deprecation warnings will be added in a future minor release.
+Under Semantic Versioning their removal requires a major release, but no removal is scheduled yet:
+whether 2.0.0 removes them depends on how future MCP spec revisions treat these features
+and on adoption of their replacements.
+
+## Conformance
+
+The SDK maintains a 100% conformance pass rate as new scenarios are added to the conformance suite.
+Legacy SSE transport (2024-11-05) is intentionally out of scope; the SDK provides modern Streamable HTTP only.
+
+## Documentation
+
+Reference documentation covers all core features.
+
+## Tracking New Spec Revisions
+
+The SDK aims to support each new MCP specification revision, with the implementation timeline agreed per
+release based on feature complexity.
+Additive features from the 2026-07-28 revision (such as `server/discover`, multi round-trip requests,
+and the tasks extension) ship as opt-in functionality during 1.x. Breaking parts of that revision,
+such as the SEP-2575 stateless lifecycle rewrite, are reserved for 2.0.


### PR DESCRIPTION
## Motivation and Context

The SDK tiering system (SEP-1730) requires a published roadmap for both Tier 1 and Tier 2. Until now the Ruby SDK had no roadmap document, which left users without visibility into upcoming feature support and blocked the tiering requirement.

This document records the SDK's current conformance status (all server and client scenarios passing), the API stability policy backed by Semantic Versioning and VERSIONING.md, the handling of features deprecated by the 2026-07-28 spec revision (SEP-2577), and how new MCP spec revisions will be tracked. Legacy SSE transport is explicitly called out as out of scope so users are not left guessing about it.

## How Has This Been Tested?

Documentation-only change; there is no code to exercise. The conformance figures cited in the roadmap were taken from the current SEP-1730 tier assessment run against the latest main.

## Breaking Changes

None. This adds a new top-level Markdown document and touches no code.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
