### PR TITLE
Fix a `NoMethodError` on Ruby 2.7 caused by `Hash#except`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -30,7 +30,7 @@ task :conformance do |t|
   options[:verbose] = true if ENV["VERBOSE"]
 
   Conformance::ServerRunner.new(**options).run
-  Conformance::ClientRunner.new(**options.except(:port)).run
+  Conformance::ClientRunner.new(**options.reject { |key, _value| key == :port }).run
 end
 
 desc "List available conformance scenarios"


### PR DESCRIPTION
## Motivation and Context

The gemspec already declares `required_ruby_version >= 2.7.0`, but the conformance Rake task used `Hash#except` to drop the `:port` option before handing the remaining options to `Conformance::ClientRunner`. `Hash#except` was only added in Ruby 3.0, so running `rake conformance` on Ruby 2.7 aborted before any scenario ran, raising `NoMethodError: undefined method except for {}:Hash`.

CI missed this because no job runs `rake conformance` on Ruby 2.7: the conformance workflow runs only on Ruby 4.0, while the Ruby 2.7.0 matrix entry runs `rake test` alone.

## How Has This Been Tested?

Replace `options.except(:port)` with `options.reject { |key, _| key == :port }`, which has been available since well before Ruby 2.7 and returns an equivalent Hash without mutating the original. `rake conformance` now runs the full suite on Ruby 2.7, and its baseline still passes on current Ruby, verified on Ruby 4.0.

## Breaking Changes

None.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
