### PR TITLE
Release 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0] - 2026-07-24
+
+First stable release. The public API is now stable: breaking changes ship only in major releases,
+apart from the narrow exceptions documented in [VERSIONING.md](VERSIONING.md).
+
+### Added
+
+- Add `ROADMAP.md` outlining the path toward SEP-1730 (#465)
+- Add `VERSIONING.md` documenting the versioning and breaking-change policy (#466)
+
 ## [0.25.0] - 2026-07-18
 
 ### Added

--- a/lib/mcp/version.rb
+++ b/lib/mcp/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MCP
-  VERSION = "0.25.0"
+  VERSION = "1.0.0"
 end


### PR DESCRIPTION
@modelcontextprotocol/ruby-sdk 

This first stable release marks the public API as stable per SEP-1730: breaking changes now ship only in major releases, with the narrow exceptions documented in VERSIONING.md. The release adds ROADMAP.md and VERSIONING.md and contains no behavior changes.

Future feature proposals can be incorporated without breaking changes. No incompatibilities have been identified with the known issues and pull requests.

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
