### PR TITLE
Release 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-08-01
+
+### Added
+
+- Support 2026-07-28 as the Latest Protocol Version (#476)
+- Expose server tool annotations on MCP::Client::Tool (#445)
+
+### Fixed
+
+- Preserve explicit tool response content (#469)
+
 ## [1.0.0] - 2026-07-24
 
 First stable release. The public API is now stable: breaking changes ship only in major releases,

--- a/lib/mcp/version.rb
+++ b/lib/mcp/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MCP
-  VERSION = "1.0.0"
+  VERSION = "1.1.0"
 end


### PR DESCRIPTION
@modelcontextprotocol/ruby-sdk

This release primarily addresses https://github.com/modelcontextprotocol/ruby-sdk/issues/474. Work on full support for the 2026-07-28 specification, including stateless mode, is ongoing and will continue in future releases.

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
