### PR TITLE
Suppress RuboCop extension suggestions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,7 @@ plugins:
 
 AllCops:
   TargetRubyVersion: 2.7
+  SuggestExtensions: false
 
 Gemspec/DevelopmentDependencies:
   Enabled: true


### PR DESCRIPTION
This PR suppresses the following information:

```console
$ bundle exec rubocop
(snip)

Tip: Based on detected gems, the following RuboCop extension libraries might be helpful:
  * rubocop-i18n (https://rubygems.org/gems/rubocop-i18n)

You can opt out of this message by adding the following to your config
(see https://docs.rubocop.org/rubocop/plugins.html#plugin-suggestions for more options):
  AllCops:
    SuggestExtensions: false
```

There's no need to introduce a third-party RuboCop extension unless there's a specific need.

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
