### PR TITLE
Stamp the required `resultType` on modern results per SEP-2322

### DIFF
--- a/README.md
+++ b/README.md
@@ -2851,6 +2851,10 @@ The Ruby client recognizes such results and raises `MCP::Client::InputRequiredEr
 and the raw `result`; automatic resumption is not implemented yet, so callers respond manually if they opt into the draft flow. `MCP::ResultType::COMPLETE` and `MCP::ResultType::INPUT_REQUIRED`
 are provided for forward compatibility. Servers on stable protocol versions never send `resultType`, so existing behavior is unchanged.
 
+SEP-2322 also makes `resultType` a required member of every result a 2026-07-28 server returns. The server stamps `resultType: "complete"` on all results of requests carrying
+the modern `_meta` envelope (and on `server/discover` results), while results that already carry a discriminator (`"input_required"`, the tasks extension's `"task"`) keep it.
+Legacy results stay unstamped, and clients treat an absent `resultType` as `"complete"` per the spec.
+
 ## Conformance Testing
 
 The `conformance/` directory contains a test server and runner that validate the SDK against the MCP specification using [`@modelcontextprotocol/conformance`](https://github.com/modelcontextprotocol/conformance).

--- a/lib/mcp/server.rb
+++ b/lib/mcp/server.rb
@@ -621,6 +621,14 @@ module MCP
             result = serialize_input_required_result(result, envelope: envelope, request: params)
           end
 
+          # SEP-2322 makes `resultType` REQUIRED on every result a 2026-07-28 server returns;
+          # a missing value is only tolerated FROM earlier protocol versions. Results that already carry
+          # a discriminator keep it; everything else on the modern wire is the standard shape,
+          # `"complete"`. Legacy results stay unstamped: pre-2026 clients do not know the field.
+          if envelope && result.is_a?(Hash) && !result.key?(:resultType)
+            result = result.merge(resultType: ResultType::COMPLETE)
+          end
+
           result
         rescue CancelledError => e
           add_instrumentation_data(cancelled: true, cancellation_reason: e.reason)
@@ -837,7 +845,13 @@ module MCP
         capabilities: capabilities,
         instructions: instructions,
         _meta: { RequestEnvelope::SERVER_INFO_META_KEY => server_info },
-      }.compact.merge(ttlMs: ttl_ms || 0, cacheScope: cache_scope || "private")
+      }.compact.merge(
+        ttlMs: ttl_ms || 0,
+        cacheScope: cache_scope || "private",
+        # `server/discover` is exempt from the `_meta` envelope, so the central modern-result stamping does not see it;
+        # `DiscoverResult` is still a 2026-07-28 result and carries the REQUIRED `resultType` directly.
+        resultType: ResultType::COMPLETE,
+      )
     end
 
     def configure_logging_level(request, session: nil)

--- a/test/mcp/server_test.rb
+++ b/test/mcp/server_test.rb
@@ -4142,6 +4142,42 @@ module MCP
       refute Apps.client_supports?(server.client_capabilities)
     end
 
+    # SEP-2322 makes `resultType` REQUIRED on every result of a 2026-07-28 server;
+    # `"complete"` is the standard shape, and legacy results stay unstamped.
+    test "modern results carry resultType complete" do
+      server = Server.new(name: "result_type_test", tools: [result_type_tool])
+
+      [
+        modern_request(Methods::TOOLS_LIST, {}),
+        modern_request(Methods::PING, {}),
+        modern_request(Methods::TOOLS_CALL, { name: "result_type_tool", arguments: {} }),
+      ].each do |request|
+        response = server.handle(request)
+        assert_equal "complete", response.dig(:result, :resultType), "expected stamp for #{request[:method]}"
+      end
+    end
+
+    test "legacy results carry no resultType" do
+      server = Server.new(name: "result_type_test", tools: [result_type_tool])
+
+      [
+        { jsonrpc: "2.0", method: Methods::TOOLS_LIST, id: 1 },
+        { jsonrpc: "2.0", method: Methods::PING, id: 2 },
+        { jsonrpc: "2.0", method: Methods::TOOLS_CALL, id: 3, params: { name: "result_type_tool", arguments: {} } },
+      ].each do |request|
+        response = server.handle(request)
+        refute response[:result].key?(:resultType), "expected no stamp for #{request[:method]}"
+      end
+    end
+
+    test "server/discover carries resultType complete" do
+      server = Server.new(name: "result_type_test", tools: [result_type_tool])
+
+      response = server.handle({ jsonrpc: "2.0", method: Methods::SERVER_DISCOVER, id: 1 })
+
+      assert_equal "complete", response.dig(:result, :resultType)
+    end
+
     private
 
     # Builds a request carrying the SEP-2575 modern `_meta` envelope.
@@ -4158,6 +4194,12 @@ module MCP
           },
         ),
       }
+    end
+
+    def result_type_tool
+      @result_type_tool ||= Tool.define(name: "result_type_tool") do |**|
+        Tool::Response.new([{ type: "text", text: "ok" }])
+      end
     end
   end
 end


### PR DESCRIPTION
## Motivation and Context

SEP-2322 (merged for the 2026-07-28 spec release) makes `resultType` a REQUIRED member of every result a 2026-07-28 server returns: "Servers implementing this protocol version MUST include this field", with absence tolerated only when the result comes FROM an earlier protocol version. The client-side vocabulary landed earlier (`MCP::ResultType`, treating an absent value as `"complete"`), but every ordinary modern result the server returns is unstamped, which violates the MUST for `tools/list`, `tools/call`, `ping`, and every other standard result on the modern wire. The conformance suite's 2026-07-28 requirements fail each of those scenarios on wire-schema validation (`CallToolResult: must have required property 'resultType'`).

The dispatch path now stamps `resultType: "complete"` centrally: any Hash result of a request carrying the SEP-2575 `_meta` envelope that does not already carry a `resultType` gets the standard value merged in. Results that already carry a discriminator keep it, notifications and cancellation-suppressed responses are untouched, and legacy results stay unstamped because pre-2026 clients do not know the field. `server/discover`, which is exempt from the `_meta` envelope (pre-version discovery), stamps its `DiscoverResult` at its construction site instead.

## How Has This Been Tested?

`bundle exec rake test` passes with zero failures. New tests in `test/mcp/server_test.rb`: `tools/list`, `ping`, and `tools/call` results carry `resultType: "complete"` on modern requests and no `resultType` on legacy requests; `server/discover` carries the stamp. The conformance scenarios previously failing on the missing property (`tools-call-simple-text`, `prompts-get-simple`, `completion-complete`, and the other tools/prompts scenarios) pass at `--spec-version 2026-07-28` against the conformance fixture server.

## Breaking Changes

None. The stamp applies only to results of requests carrying the SEP-2575 modern `_meta` envelope; results on stable protocol versions through 2025-11-25 are byte-for-byte unchanged.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
