### PR TITLE
[Conformance] Raise `ResourceNotFoundError` for unknown resource URIs

### DIFF
--- a/conformance/server.rb
+++ b/conformance/server.rb
@@ -577,7 +577,9 @@ module Conformance
             ).to_h,
           ]
         else
-          []
+          # Per SEP-2164, an unknown URI answers with -32602 carrying the URI in `error.data`;
+          # an empty `contents` array is forbidden.
+          raise MCP::Server::ResourceNotFoundError.new(uri, params)
         end
       end
     end


### PR DESCRIPTION
## Motivation and Context

Per SEP-2164, a `resources/read` request for a nonexistent resource answers with JSON-RPC error -32602 carrying the requested URI in `error.data`, and MUST NOT return an empty `contents` array. The SDK supports this via `MCP::Server::ResourceNotFoundError` (#402), but the conformance fixture's `resources_read_handler` returned an empty array for unknown URIs, so the `sep-2164-resource-not-found` scenario of the 2026-07-28 conformance requirements fails on the fixture ("Server returned a result with an empty contents array").

The gap never surfaced before because the scenario is part of the 2026-07-28 requirement set only; the 2025-11-25 suite the fixture has been passing does not run it. The fixture now raises `ResourceNotFoundError`, which is also the documented pattern for `resources_read_handler` users.

## How Has This Been Tested?

- `sep-2164-resource-not-found` passes 4/4 checks at `--spec-version 2026-07-28` against the fixture server.
- The `--requirements 2025-11-25` server leg passes 78/78, and each resources scenario reports no change, so known URIs are unaffected.
- RuboCop reports no offenses on the changed file.

## Breaking Changes

None. The change is confined to the conformance fixture; the shipped gem is untouched.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
