### PR TITLE
Stop using `ping` as the non-cacheable result example

### DIFF
--- a/test/mcp/server_test.rb
+++ b/test/mcp/server_test.rb
@@ -4378,7 +4378,10 @@ module MCP
     test "modern non-cacheable results carry no cache hints" do
       server = Server.new(name: "cache_hints_test", tools: [result_type_tool])
 
-      response = server.handle(modern_request(Methods::PING, {}))
+      # `tools/call` is the non-cacheable example here: the spec types `CallToolResult` as a plain `Result`,
+      # while the results it types as `CacheableResult` are the discover, list, and read families.
+      # `ping` cannot stand in for it - SEP-2575 removed that method, so a modern request naming it is refused.
+      response = server.handle(modern_request(Methods::TOOLS_CALL, { name: "result_type_tool", arguments: {} }))
 
       refute response[:result].key?(:ttlMs)
       refute response[:result].key?(:cacheScope)


### PR DESCRIPTION
## Motivation and Context

`main` is red on every Ruby version: "modern non-cacheable results carry no cache hints" errors with `undefined method 'key?' for nil`. The test reaches for `response[:result]` on a request that no longer produces a result.

Two changes met on `main` without conflicting textually. #499 added the test and picked `ping` as its example of a result that is not cacheable. #511 then made a modern-enveloped request naming a method SEP-2575 removed answer with `-32601` even before the connection era locks, and `ping` is one of those methods, so the response now carries an error rather than a result. Each branch was green against the `main` it was written on; the pairing only failed once both had landed.

`ping` was the wrong example regardless. It is absent from the 2026-07-28 schema, so no modern request can name it and receive a result of any shape. `tools/call` is the accurate stand-in: the spec types `CallToolResult` as a plain `Result`, while the ones it types as `CacheableResult` are the discover, list, and read families. The test now calls the tool it already registers, and a comment records why `ping` cannot come back here - the same note #511 left where it replaced `ping` with `prompts/list` in the neighboring `resultType` test.

Only the test changes. The behavior both #499 and #511 implement is correct; the example the test chose was not.

## How Has This Been Tested?

The test errors on `main` and passes with this change. `bundle exec rake` (tests, RuboCop, and conformance baseline) passes. The rest of the suite was searched for the same pattern, a modern-enveloped request naming a method the modern lifecycle removed: the only other occurrence is the assertion #511 added deliberately, which checks that such a request does not lock the era, and which reads no result.

## Breaking Changes

None. No library code changes.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
