### PR TITLE
Drive the `http-standard-headers` scenario in the conformance client

### DIFF
--- a/conformance/client.rb
+++ b/conformance/client.rb
@@ -238,6 +238,21 @@ begin
     # calling only the valid one shows the invalid definitions did not block it.
     client.tools
     client.call_tool(name: "valid_tool", arguments: { "message" => "hello" })
+  when "http-standard-headers"
+    # SEP-2243: the harness inspects the `Mcp-Method` header on every POST and the `Mcp-Name` header on
+    # the name-carrying requests, so drive one of each standard request kind.
+    tools = client.tools
+    tool = tools.find { |t| t.name == "test_headers" } || tools.first
+    abort("No tool exposed by conformance server for #{scenario}") unless tool
+    client.call_tool(tool: tool, arguments: {})
+
+    resource = client.resources.first
+    abort("No resource exposed by conformance server for #{scenario}") unless resource
+    client.read_resource(uri: resource["uri"])
+
+    prompt = client.prompts.first
+    abort("No prompt exposed by conformance server for #{scenario}") unless prompt
+    client.get_prompt(name: prompt["name"])
   when "json-schema-ref-no-deref"
     # SEP-2106: listing tools whose schemas carry `$ref` must not trigger network dereferencing.
     client.tools


### PR DESCRIPTION
## Motivation and Context

The 2026-07-28 requirement set scores `http-standard-headers` (SEP-2243) on the client leg, but `conformance/client.rb` had no case for it: the scenario hit the unknown-scenario abort, the client exited 1, and every `Mcp-Method` / `Mcp-Name` check reported SKIPPED ("Client did not send a ... request"), failing the scenario in tier-check. The 2026-08-14 tier audit flagged this as the only scored conformance failure (client leg 49/50).

The transport already sends the standard headers on the modern path; what was missing is a driver that exercises each request kind the harness observes. The new case issues `tools/list`, `tools/call` (the `test_headers` fixture tool), `resources/list`, `resources/read` (the first listed resource URI), `prompts/list`, and `prompts/get` (the first listed prompt), letting the harness see the `Mcp-Method` header on every POST and the `Mcp-Name` header on the three name-carrying requests. The `initialize` / `notifications/initialized` rows stay SKIPPED by design: the 2026-07-28 wire is stateless, so those requests are never sent.

## How Has This Been Tested?

`conformance client --scenario http-standard-headers --spec-version 2026-07-28` passes 9/9 checks, and the full `--requirements 2026-07-28` client leg exits 0 with every scored scenario passing (435 checks; the only failures are the baselined not-scored DPoP/WIF extensions). RuboCop is clean.

## Breaking Changes

None. The change only adds a scenario driver to the conformance client fixture; library code is untouched.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

