### PR TITLE
[Doc] Add prompts/resources list-changed notification examples to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2226,6 +2226,18 @@ transport = MCP::Server::Transports::StreamableHTTPTransport.new(server)
 # When tools change, notify clients
 server.define_tool(name: "new_tool") { |**args| { result: "ok" } }
 server.notify_tools_list_changed
+
+# When prompts change, notify clients
+server.define_prompt(name: "new_prompt") do |args, server_context:|
+  MCP::Prompt::Result.new(messages: [])
+end
+server.notify_prompts_list_changed
+
+# When resources change, notify clients
+server.define_resource(uri: "resource://new", name: "new_resource", mime_type: "text/plain") do
+  [MCP::Resource::TextContents.new(uri: "resource://new", mime_type: "text/plain", text: "contents")]
+end
+server.notify_resources_list_changed
 ```
 
 You can use Stateless Streamable HTTP, where notifications are not supported and all calls are request/response interactions.


### PR DESCRIPTION
## Motivation and Context

The SDK tiering system (SEP-1730) requires Tier 1 SDKs to document all non-experimental features with examples. The 2026-08-14 documentation coverage audit found the last two example gaps: the Notifications section documents `notify_prompts_list_changed` and `notify_resources_list_changed` in prose, but only `notify_tools_list_changed` appeared in a code example, leaving the prompts and resources variants PARTIAL.

The Usage Example in the notifications chapter now defines a prompt and a resource and broadcasts the matching list-changed notification for each, alongside the existing tools example. The block signatures mirror the canonical `define_prompt` / `define_resource` examples earlier in the README.md.

## How Has This Been Tested?

Documentation-only change. The snippet was verified end to end against the current public API: both definitions serve `prompts/get` / `resources/read` responses and all three notify calls run without error.

## Breaking Changes

None. This only extends a code example in README.md.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
