### PR TITLE
Return Invalid Params for unknown prompts and missing prompt arguments

### DIFF
--- a/lib/mcp/prompt.rb
+++ b/lib/mcp/prompt.rb
@@ -111,8 +111,15 @@ module MCP
         missing = required_args - args.keys
         return if missing.empty?
 
+        # The explicit `error_code` maps a missing prompt argument to Invalid Params (-32602) rather
+        # than the default Internal Error (-32603); a missing required argument is client input, not a
+        # server fault. `error_type: :missing_required_arguments` keeps the descriptive message and
+        # instrumentation label. Mirrors `MCP::Server::ResourceNotFoundError`.
         raise MCP::Server::RequestHandlerError.new(
-          "Missing required arguments: #{missing.join(", ")}", nil, error_type: :missing_required_arguments
+          "Missing required arguments: #{missing.join(", ")}",
+          nil,
+          error_type: :missing_required_arguments,
+          error_code: JsonRpcHandler::ErrorCode::INVALID_PARAMS,
         )
       end
 

--- a/lib/mcp/server.rb
+++ b/lib/mcp/server.rb
@@ -1260,7 +1260,16 @@ module MCP
       prompt = @prompts[prompt_name]
       unless prompt
         add_instrumentation_data(error: :prompt_not_found)
-        raise RequestHandlerError.new("Prompt not found #{prompt_name}", request, error_type: :prompt_not_found)
+        # The explicit `error_code` maps an unknown prompt to Invalid Params (-32602) rather than
+        # the default Internal Error (-32603), matching the `tools/call`, `resources/read`, and
+        # `completion/complete` siblings for the same not-found condition, while `error_type:
+        # :prompt_not_found` keeps the descriptive message and instrumentation label.
+        raise RequestHandlerError.new(
+          "Prompt not found #{prompt_name}",
+          request,
+          error_type: :prompt_not_found,
+          error_code: JsonRpcHandler::ErrorCode::INVALID_PARAMS,
+        )
       end
 
       add_instrumentation_data(prompt_name: prompt_name)

--- a/test/mcp/server_test.rb
+++ b/test/mcp/server_test.rb
@@ -1395,6 +1395,9 @@ module MCP
       }
 
       response = @server.handle(request)
+      # An unknown prompt is client input, so it maps to Invalid Params (-32602), not the
+      # default Internal Error (-32603); matches the tools/call and completion/complete siblings.
+      assert_equal JsonRpcHandler::ErrorCode::INVALID_PARAMS, response.dig(:error, :code)
       assert_equal("Prompt not found unknown_prompt", response[:error][:data])
       assert_instrumentation_data({ method: "prompts/get", error: :prompt_not_found })
     end
@@ -1411,6 +1414,9 @@ module MCP
       }
 
       response = @server.handle(request)
+      # A missing required argument is client input, so it maps to Invalid Params (-32602),
+      # not the default Internal Error (-32603).
+      assert_equal JsonRpcHandler::ErrorCode::INVALID_PARAMS, response.dig(:error, :code)
       assert_equal "Missing required arguments: test_argument", response[:error][:data]
       assert_instrumentation_data({
         method: "prompts/get",


### PR DESCRIPTION
## Summary

`prompts/get` returns Internal Error (-32603) when the prompt name is unknown or a required argument is missing. Both are client input errors, so the JSON-RPC error code should be Invalid Params (-32602), which is what the sibling handlers already return for the same conditions.

## Current behavior

Requesting an unknown prompt:

```json
{"jsonrpc":"2.0","id":1,"error":{"code":-32603,"message":"Internal error","data":"Prompt not found ghost"}}
```

`completion/complete` (`Server#complete`), asked to complete an argument for that same unknown prompt, already returns -32602. The two handlers return different codes for the one condition.

## Why Invalid Params

The not-found and missing-input paths of the neighboring methods already map to -32602:

- `tools/call` unknown tool, in `Server#call_tool`
- `resources/read` unknown resource, via `ResourceNotFoundError`, standardized to -32602 in SEP-2164
- `completion/complete` unknown prompt, in `Server#complete`

`prompts/get` was the only not-found path left on -32603.

## Change

Add an explicit `error_code: JsonRpcHandler::ErrorCode::INVALID_PARAMS` at the two `prompts/get` raise sites:

- unknown prompt, in `Server#get_prompt`
- missing required argument, in `Prompt.validate_arguments!`

This follows the `ResourceNotFoundError` pattern already in the tree: the wire code becomes -32602 and the descriptive message is surfaced, while `error_type` stays `:prompt_not_found` / `:missing_required_arguments` so the existing instrumentation labels are unchanged.

After:

```json
{"jsonrpc":"2.0","id":1,"error":{"code":-32602,"message":"Prompt not found ghost","data":"Prompt not found ghost"}}
```

## Tests

Extended the two existing `prompts/get` error tests to assert the -32602 code; they fail on the current code and pass with the fix. `bundle exec rake` is green (1701 runs, 0 failures), RuboCop reports no offenses, and the conformance baseline is unchanged.