### PR TITLE
Refresh ROADMAP.md for the shipped 2026-07-28 support

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,18 +5,22 @@ It is a living document and will evolve as the SDK matures.
 
 ## Current Status
 
-The SDK implements the 2025-06-18 and 2025-11-25 spec revisions, and passes all server and client conformance scenarios.
+The SDK implements the 2025-06-18, 2025-11-25, and 2026-07-28 spec revisions, and passes all scored server
+and client conformance scenarios for each revision's requirement set.
+Optional protocol extensions (such as DPoP, workload identity federation, and the tasks extension)
+are not yet implemented; SEP-1730 does not require extensions for any tier.
 
 ## API Stability
 
-The 1.0.0 release will mark the public API as stable: breaking changes then ship only in major releases,
+The 1.0.0 release marked the public API as stable: breaking changes ship only in major releases,
 apart from the narrow exceptions documented in [VERSIONING.md](VERSIONING.md),
 which also defines the Semantic Versioning scheme and breaking-change policy.
 
 ## Deprecated Features
 
 The 2026-07-28 spec revision deprecates Roots, Sampling, and Logging (SEP-2577).
-These features remain fully supported throughout 1.x, and deprecation warnings will be added in a future minor release.
+These features remain fully supported throughout 1.x, and the SDK emits deprecation warnings when they are used
+with protocol version 2026-07-28 or newer.
 Under Semantic Versioning their removal requires a major release, but no removal is scheduled yet:
 whether 2.0.0 removes them depends on how future MCP spec revisions treat these features
 and on adoption of their replacements.
@@ -28,12 +32,16 @@ Legacy SSE transport (2024-11-05) is intentionally out of scope; the SDK provide
 
 ## Documentation
 
-Reference documentation covers all core features.
+Reference documentation covers all non-experimental features with examples.
 
 ## Tracking New Spec Revisions
 
 The SDK aims to support each new MCP specification revision, with the implementation timeline agreed per
 release based on feature complexity.
-Additive features from the 2026-07-28 revision (such as `server/discover`, multi round-trip requests,
-and the tasks extension) ship as opt-in functionality during 1.x. Breaking parts of that revision,
-such as the SEP-2575 stateless lifecycle rewrite, are reserved for 2.0.
+The 2026-07-28 revision shipped during 1.x: the server serves both lifecycle eras side by side,
+so the SEP-2575 stateless lifecycle (including `server/discover` and `subscriptions/listen`),
+SEP-2322 multi round-trip requests, SEP-2549 cache hints, and SEP-2243 custom headers are available alongside
+the legacy handshake. The few incompatible adjustments the revision required shipped in
+a minor release under the spec-conformance and security exceptions described in [VERSIONING.md](VERSIONING.md).
+Removing legacy-era support is reserved for a future major release.
+The tasks extension (SEP-2663) remains planned ([#391](https://github.com/modelcontextprotocol/ruby-sdk/issues/391)).


### PR DESCRIPTION
## Motivation and Context

The roadmap predates the 2026-07-28 implementation work and has drifted from the released SDK. The 2026-08-15 SEP-1730 tier audit flagged the drift while evaluating the roadmap requirement:

- "Current Status" claims only 2025-06-18 and 2025-11-25 support, but the SDK now completes the 2026-07-28 revision and passes all scored server and client conformance scenarios for each revision's requirement set.
- The SEP-2575 stateless lifecycle rewrite was described as reserved for 2.0, but it shipped during 1.x with both lifecycle eras served side by side; the few incompatible adjustments shipped in a minor release under the spec-conformance and security exceptions described in VERSIONING.md, as recorded in the 1.2.0 CHANGELOG entry.
- Deprecation warnings for Roots/Sampling/Logging (SEP-2577) were described as future work but have shipped (#406, #516).
- The documentation section undersold the coverage: all implemented non-experimental features are documented with examples (#472, #515).

The refreshed text records the implemented spec revisions and how the 2026-07-28 revision actually shipped, and keeps the tasks extension (SEP-2663, #391) and the removal of legacy-era support as the remaining tracked items. Gem versions are deliberately not named: the roadmap describes the current state of the SDK, and the version-to-revision mapping already lives in CHANGELOG.md.

## How Has This Been Tested?

Documentation-only change; no code paths are affected. Statements were cross-checked against the v1.2.0 CHANGELOG entry and the 2026-08-15 tier audit results (server 67/67 and client 50/50 scored conformance across the 2025-11-25 and 2026-07-28 requirement sets).

## Breaking Changes

None. This only updates ROADMAP.md.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
