### PR TITLE
Release 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-08-22
+
+User-facing documentation now lives on the documentation site at https://ruby.sdk.modelcontextprotocol.io,
+and README.md keeps the quick start. Two entries under "Changed" reject traffic that earlier releases accepted
+and ship in a minor release under the exceptions described in [VERSIONING.md](VERSIONING.md).
+
+### Added
+
+- Add a `resources_list_handler` for context-dependent resource lists (#509)
+- Pass a handler-returned `_meta` through the subscribe result (#510)
+
+### Changed
+
+- Bound OAuth response bodies in the client (#520)
+- Reject duplicate in-flight JSON-RPC request ids (#521)
+- Move the documentation from README.md to the documentation site (#523)
+
 ## [1.2.0] - 2026-08-15
 
 This release completes the SEP-2575 stateless lifecycle of the 2026-07-28 specification, together with

--- a/lib/mcp/version.rb
+++ b/lib/mcp/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MCP
-  VERSION = "1.2.0"
+  VERSION = "1.3.0"
 end


### PR DESCRIPTION
This release adds a `resources_list_handler` so `resources/list` can be served per-connection, passes handler-returned `_meta` through subscription results, and moves the user-facing documentation from README.md to the documentation site at https://ruby.sdk.modelcontextprotocol.io.

Two entries under "Changed" are incompatible with 1.2.0 and ship in a minor release under the exceptions in VERSIONING.md: OAuth endpoint responses larger than 4 MiB are refused, and a request whose id is already in flight on the same session is answered with Invalid Request.

> [!IMPORTANT]
> The documentation moves with #523, and the site deploys only through the release workflow, so #523 needs to be merged immediately before this release.

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
