### PR TITLE
[Doc] Align the ROADMAP deprecation wording with the shipped behavior

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,11 +19,15 @@ which also defines the Semantic Versioning scheme and breaking-change policy.
 ## Deprecated Features
 
 The 2026-07-28 spec revision deprecates Roots, Sampling, and Logging (SEP-2577).
-These features remain fully supported throughout 1.x, and the SDK emits deprecation warnings when they are used
-with protocol version 2026-07-28 or newer.
-Under Semantic Versioning their removal requires a major release, but no removal is scheduled yet:
-whether 2.0.0 removes them depends on how future MCP spec revisions treat these features
-and on adoption of their replacements.
+These features remain supported throughout 1.x: on the legacy lifecycle they work unchanged
+(the deprecations do not apply there), and the 2026-07-28 lifecycle carries them through its own mechanisms:
+roots-shaped and sampling-shaped input requests embedded in `InputRequiredResult` responses
+(the SEP-2322 multi round-trip requests pattern) and per-request log delivery through the envelope's `logLevel`.
+The replacements SEP-2577 names live outside the protocol: tool parameters or configuration for roots,
+direct LLM provider APIs for sampling, and stderr or OpenTelemetry for logging.
+The client emits a deprecation warning when a modern connect declares the deprecated Roots or Sampling capabilities.
+Under Semantic Versioning their removal requires a major release, but no removal is scheduled yet: whether 2.0.0 removes
+them depends on how future MCP spec revisions treat these features and on adoption of their replacements.
 
 ## Conformance
 


### PR DESCRIPTION
## Motivation and Context

The Deprecated Features paragraph still described the pre-#516 design, claiming the SDK "emits deprecation warnings when they are used with protocol version 2026-07-28 or newer". Since #516 the only deprecation warning is the client-side one, emitted on a modern connect that declares the Roots or Sampling capabilities, exactly as the 1.2.0 CHANGELOG entry states. Logging never warns (`notify_log_message` is the sanctioned SEP-2575 delivery path on that wire), and the server never warns either: `initialize` counter-offers a legacy version, a modern `Configuration` pin is rejected at construction, and the modern lifecycle refuses the deprecated server-to-client request APIs outright rather than serving them with a warning. The paragraph now describes the shipped behavior and says where each feature lives per lifecycle: unchanged on legacy, carried on 2026-07-28 by input requests embedded in `InputRequiredResult` responses (the SEP-2322 multi round-trip requests pattern) and the envelope's `logLevel`. Those carriers are not the SEP-2577 replacements: the spec's deprecated-features registry points migrating implementations outside the protocol (tool parameters or configuration, direct LLM provider APIs, stderr or OpenTelemetry), and the paragraph now says so instead of presenting the modern delivery forms as the replacements.

## How Has This Been Tested?

Documentation-only change; proofread against the `ProtocolDeprecations` module header and the CHANGELOG entry that shipped this behavior in 1.2.0, which the 1.3.0 release leaves unchanged.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
