### PR TITLE
[Doc] Replace the theme attribution in the nav footer

### DIFF
--- a/docs/_includes/nav_footer_custom.html
+++ b/docs/_includes/nav_footer_custom.html
@@ -1,0 +1,14 @@
+{%- comment -%}
+  Replaces the theme's "This site uses Just the Docs" attribution, shown at
+  the bottom of the sidebar on desktop and in the page footer on mobile.
+  _data/versions.yml exists only on the deployed gh-pages tree, where
+  bin/generate-gh-pages.sh generates it; without it (local previews of
+  the docs/ source) only the license sentence renders.
+{%- endcomment -%}
+{% if site.data.versions %}
+Documentation for <a href="https://rubygems.org/gems/mcp/versions/{{ site.data.versions | first }}">mcp {{ site.data.versions | first }}</a>,
+licensed <a href="https://creativecommons.org/licenses/by/4.0/">CC-BY-4.0</a>.
+{% else %}
+Documentation licensed <a href="https://creativecommons.org/licenses/by/4.0/">CC-BY-4.0</a>.
+{% endif %}
+See <a href="https://github.com/modelcontextprotocol/ruby-sdk/blob/main/LICENSE">LICENSE</a> for the code.


### PR DESCRIPTION
The bottom of the sidebar (and the mobile page footer) showed the theme's fallback line "This site uses Just the Docs, a documentation theme for Jekyll", which tells readers nothing about the SDK. Overriding nav_footer_custom.html replaces it with the release the documentation describes, linking the RubyGems page of the version deployed via _data/versions.yml by bin/generate-gh-pages.sh, and with the licensing: the documentation is CC-BY-4.0 per LICENSE, while the code licensing is delegated to LICENSE itself, whose consent-based MIT to Apache-2.0 transition does not fit a footer phrase. Without versions data (local previews of the docs/ source) only the license sentences render.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
