### PR TITLE
Release 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0] - 2026-08-28
+
+This release repairs the `subscriptions/listen` stream. A host that buffers its responses,
+the documented Rails controller pattern among them, can decline the method with
+`serve_subscriptions_listen: false` instead of answering a modern client with a streaming body
+it cannot render, and the stream's ordering guarantees are enforced: no notification reaches
+a client before the acknowledgement, and none follows the graceful closing result.
+
+### Added
+
+- Add `serve_subscriptions_listen:` for hosts that cannot hold an SSE stream open (#533)
+
+### Fixed
+
+- Deliver `subscriptions/listen` notifications only after the acknowledgement (#532)
+- Serialize `subscriptions/listen` writes so the graceful result is the final message (#535)
+
 ## [1.3.0] - 2026-08-22
 
 User-facing documentation now lives on the documentation site at https://ruby.sdk.modelcontextprotocol.io,

--- a/lib/mcp/version.rb
+++ b/lib/mcp/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MCP
-  VERSION = "1.3.0"
+  VERSION = "1.4.0"
 end


### PR DESCRIPTION
@modelcontextprotocol/ruby-sdk 

This release repairs the `subscriptions/listen` stream: a host that buffers its responses, the documented Rails controller pattern among them, can decline the method with `serve_subscriptions_listen: false` instead of answering a modern client with a streaming body it cannot render, and the stream's ordering guarantees are enforced - no notification before the acknowledgement, none after the graceful closing result.

The new keyword argument is what makes this a minor release; everything else is a bug fix. The controller-pattern crash is a regression from 1.2.0, where the modern lifecycle began answering `subscriptions/listen` that earlier versions had refused as an unknown method, and it fails quietly: only the notification stream breaks, so tool calls keep working.

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
