### PR TITLE
Group the conformance Rake tasks under a `conformance` namespace

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -26,4 +26,4 @@ jobs:
       - uses: actions/setup-node@v7
         with:
           node-version: '24' # Specify the latest Node.js version.
-      - run: bundle exec rake conformance
+      - run: bundle exec rake conformance:test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,8 +15,8 @@ This is the official Ruby SDK for the Model Context Protocol (MCP), implementing
 - `bundle install` - Install dependencies
 - `rake test` - Run all tests
 - `rake rubocop` - Run linter
-- `rake` - Run tests and linting (default task)
-- `bundle exec rake conformance` - Run the MCP conformance suite (see conformance/README.md)
+- `rake` - Run linting, tests, and the conformance suite (default task)
+- `bundle exec rake conformance:test` - Run the MCP conformance suite (see conformance/README.md)
 - `bundle exec rake docs:preview` - Serve the documentation site locally at http://localhost:4000 (PORT to override)
 - `ruby -I lib -I test test/path/to/specific_test.rb` - Run single test file
 - `gem build mcp.gemspec` - Build the gem

--- a/Rakefile
+++ b/Rakefile
@@ -14,42 +14,50 @@ require "rubocop/rake_task"
 
 RuboCop::RakeTask.new
 
-task default: [:rubocop, :test, :conformance]
+task default: [:rubocop, :test, "conformance:test"]
 
-desc "Run MCP conformance tests (PORT, SCENARIO, SPEC_VERSION, VERBOSE)"
-task :conformance do |t|
-  next unless npx_available?(t.name)
+namespace :conformance do
+  desc "Run MCP conformance tests (PORT, SCENARIO, SPEC_VERSION, VERBOSE)"
+  task :test do |t|
+    next unless npx_available?(t.name)
 
-  require_relative "conformance/server_runner"
-  require_relative "conformance/client_runner"
+    require_relative "conformance/server_runner"
+    require_relative "conformance/client_runner"
 
-  options = {}
-  options[:port] = Integer(ENV["PORT"]) if ENV["PORT"]
-  options[:scenario] = ENV["SCENARIO"] if ENV["SCENARIO"]
-  options[:spec_version] = ENV["SPEC_VERSION"] if ENV["SPEC_VERSION"]
-  options[:verbose] = true if ENV["VERBOSE"]
+    options = {}
+    options[:port] = Integer(ENV["PORT"]) if ENV["PORT"]
+    options[:scenario] = ENV["SCENARIO"] if ENV["SCENARIO"]
+    options[:spec_version] = ENV["SPEC_VERSION"] if ENV["SPEC_VERSION"]
+    options[:verbose] = true if ENV["VERBOSE"]
 
-  Conformance::ServerRunner.new(**options).run
-  Conformance::ClientRunner.new(**options.reject { |key, _value| key == :port }).run
+    Conformance::ServerRunner.new(**options).run
+    Conformance::ClientRunner.new(**options.reject { |key, _value| key == :port }).run
+  end
+
+  desc "List available conformance scenarios"
+  task :list do |t|
+    next unless npx_available?(t.name)
+
+    system("npx", "--yes", "@modelcontextprotocol/conformance", "list", "--server")
+    system("npx", "--yes", "@modelcontextprotocol/conformance", "list", "--client")
+  end
+
+  desc "Start the conformance server (PORT)"
+  task :server do
+    require_relative "conformance/server"
+
+    options = {}
+    options[:port] = Integer(ENV["PORT"]) if ENV["PORT"]
+
+    Conformance::Server.new(**options).start
+  end
 end
 
-desc "List available conformance scenarios"
-task :conformance_list do |t|
-  next unless npx_available?(t.name)
-
-  system("npx", "--yes", "@modelcontextprotocol/conformance", "list", "--server")
-  system("npx", "--yes", "@modelcontextprotocol/conformance", "list", "--client")
-end
-
-desc "Start the conformance server (PORT)"
-task :conformance_server do
-  require_relative "conformance/server"
-
-  options = {}
-  options[:port] = Integer(ENV["PORT"]) if ENV["PORT"]
-
-  Conformance::Server.new(**options).start
-end
+# The other two former names now fail with a "Did you mean?" suggestion, but a bare `conformance`
+# would match the `conformance/` directory: Rake synthesizes a file task for it and exits 0 without
+# running anything. This keeps the name pointing at the suite instead of at that silent no-op.
+desc "Alias for conformance:test"
+task conformance: "conformance:test"
 
 namespace :docs do
   desc "Serve the documentation site locally at http://localhost:4000 (PORT)"

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -12,7 +12,7 @@ Validates the Ruby SDK's conformance to the MCP specification using [`@modelcont
 ### Run all scenarios
 
 ```bash
-bundle exec rake conformance
+bundle exec rake conformance:test
 ```
 
 Runs both server and client conformance tests in sequence. Server conformance starts the
@@ -31,20 +31,20 @@ are allowed to fail without affecting the exit code.
 
 ```bash
 # Run a single server scenario
-bundle exec rake conformance SCENARIO=ping
+bundle exec rake conformance:test SCENARIO=ping
 
 # Use a different port with verbose output
-bundle exec rake conformance PORT=3000 VERBOSE=1
+bundle exec rake conformance:test PORT=3000 VERBOSE=1
 
 # Start the server on a specific port
-bundle exec rake conformance_server PORT=3000
+bundle exec rake conformance:server PORT=3000
 ```
 
 ### Start the server and test separately
 
 ```bash
 # Terminal 1: start the server
-bundle exec rake conformance_server
+bundle exec rake conformance:server
 
 # Terminal 2: run all scenarios
 npx @modelcontextprotocol/conformance@alpha server --url http://localhost:9292/mcp
@@ -59,7 +59,7 @@ on a single scenario. Stop the server with Ctrl+C when done.
 ### List available scenarios
 
 ```bash
-bundle exec rake conformance_list
+bundle exec rake conformance:list
 ```
 
 Prints all scenario names that can be passed to `SCENARIO`.
@@ -76,7 +76,7 @@ repository with the conformance server running:
 
 ```bash
 # Terminal 1 (this repository): start the conformance server
-bundle exec rake conformance_server
+bundle exec rake conformance:server
 
 # Terminal 2 (conformance repository): run the tier audit skill as a slash command in Claude Code
 /mcp-sdk-tier-audit /path/to/modelcontextprotocol/ruby-sdk http://localhost:9292/mcp
@@ -102,4 +102,4 @@ conformance/
 
 Known-failing scenarios are registered in `conformance/expected_failures.yml`. They are allowed to
 fail without affecting the exit code and are tracked to catch regressions.
-These are shown in the output of `bundle exec rake conformance`.
+These are shown in the output of `bundle exec rake conformance:test`.


### PR DESCRIPTION
## Motivation and Context

The three conformance tasks were named `conformance`, `conformance_list`, and `conformance_server`, spelling out with underscores the grouping that Rake expresses with namespaces.

They are now `conformance:test`, `conformance:list`, and `conformance:server`. The bare `conformance` task is kept as an alias for `conformance:test`.

## How Has This Been Tested?

By running `rake -T` to confirm the three tasks are grouped under `conformance:` with the alias listed beside them, `rake --dry-run default` to confirm that the default task resolves `conformance:test`, and `rake conformance:list` to exercise a renamed task end to end.

## Breaking Changes

None. These are development-only Rake tasks.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
