### PR TITLE
[Doc] Mark the deprecated features on the server overview

### DIFF
--- a/docs/_server/index.md
+++ b/docs/_server/index.md
@@ -22,8 +22,8 @@ It implements the Model Context Protocol specification, handling model context r
 - Supports resource registration and retrieval
 - Supports stdio and Streamable HTTP (including SSE) transports
 - Supports notifications for list changes (tools, prompts, resources)
-- Supports roots (server-to-client filesystem boundary queries)
-- Supports sampling (server-to-client LLM completion requests)
+- Supports roots (server-to-client filesystem boundary queries; deprecated as of 2026-07-28)
+- Supports sampling (server-to-client LLM completion requests; deprecated as of 2026-07-28)
 - Supports cursor-based pagination for list operations
 - Supports cancellation of in-flight requests on both server and client (notifications/cancelled)
 
@@ -37,7 +37,7 @@ It implements the Model Context Protocol specification, handling model context r
 - Multi round-trip `input_required` results (MCP 2026-07-28, SEP-2322): handlers return `MCP::Server::InputRequiredResult` to ask
   the client for additional input instead of performing a server-initiated request; see [Multi Round-Trip Requests](/server/mrtr/)
 - `ping` - Simple health check
-- `logging/setLevel` - Configures the minimum log level for the server
+- `logging/setLevel` - Configures the minimum log level for the server (deprecated as of 2026-07-28)
 - `tools/list` - Lists all registered tools and their schemas
 - `tools/call` - Invokes a specific tool with provided arguments
 - `prompts/list` - Lists all registered prompts and their schemas
@@ -48,6 +48,6 @@ It implements the Model Context Protocol specification, handling model context r
 - `resources/subscribe` - Subscribes to updates for a specific resource
 - `resources/unsubscribe` - Unsubscribes from updates for a specific resource
 - `completion/complete` - Returns autocompletion suggestions for prompt arguments and resource URIs
-- `roots/list` - Requests filesystem roots from the client (server-to-client)
-- `sampling/createMessage` - Requests LLM completion from the client (server-to-client)
+- `roots/list` - Requests filesystem roots from the client (server-to-client; deprecated as of 2026-07-28)
+- `sampling/createMessage` - Requests LLM completion from the client (server-to-client; deprecated as of 2026-07-28)
 - `elicitation/create` - Requests user input from the client (server-to-client)


### PR DESCRIPTION
The overview's Key Features and Supported Methods listed `roots`, `sampling`, and `logging/setLevel` with no deprecation marking, while their own pages carry the SEP-2577 warnings, presenting a current-looking feature surface to a reader skimming the overview. The five entries now carry the pages' "deprecated as of 2026-07-28" wording; `elicitation/create` stays unmarked - it is not deprecated, and the modern lifecycle keeps carrying it as requests embedded per the multi round-trip requests pattern.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
