### PR TITLE
Parse HTTP client response bodies without Faraday's JSON middleware

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,9 @@ gem "activesupport"
 gem "debug" if RUBY_VERSION >= "3.1"
 # Avoid i18n 1.15.0, which breaks on Ruby 3.1 (ruby-i18n/i18n#735).
 gem "i18n", "!= 1.15.0"
+# FIXME: Drop this once a json release includes https://github.com/ruby/json/pull/1072. json 3.0.0 and 3.0.1
+# forward arguments after a leading parameter, syntax Ruby 2.7.3 was the first to parse, while allowing Ruby 2.7.0.
+gem "json", "< 3" if RUBY_VERSION < "2.7.3"
 gem "rake", "~> 13.0"
 gem "sorbet-static-and-runtime" if RUBY_VERSION >= "3.0"
 gem "yard", "~> 0.9"

--- a/lib/mcp/client/http.rb
+++ b/lib/mcp/client/http.rb
@@ -723,7 +723,8 @@ module MCP
         require_faraday!
         @client ||= Faraday.new(url) do |faraday|
           faraday.request(:json)
-          faraday.response(:json)
+          # The client parses response bodies itself (`resolve_response_body`), so streamed and buffered responses
+          # take the same path; Faraday's json response middleware is deliberately left out.
           faraday.response(:raise_error)
 
           faraday.headers["Accept"] = ACCEPT_HEADER
@@ -1074,8 +1075,8 @@ module MCP
         elsif content_type&.include?("application/json")
           return parse_json_buffer(stream.buffer, method, params) unless stream.buffer.empty?
 
-          # Adapters without `on_data` support deliver the body via `response.body`,
-          # already parsed by the json response middleware.
+          # Adapters without `on_data` support deliver the body via `response.body`; a JSON middleware
+          # added by the Faraday customizer may have parsed it already.
           response.body.is_a?(String) ? parse_json_buffer(response.body, method, params) : response.body
         else
           raise RequestHandlerError.new(

--- a/test/mcp/client/http_test.rb
+++ b/test/mcp/client/http_test.rb
@@ -940,6 +940,26 @@ module MCP
         assert_equal({ "result" => { "tools" => [] } }, response)
       end
 
+      def test_send_request_parses_a_json_body_with_a_parser_taking_keyword_options_only
+        # json 3.0 accepts parser options as keywords only, and Faraday's json response middleware
+        # passes them as a positional Hash, which Ruby 3 no longer converts. The stand-in parser has
+        # the json 3.0 signature, so the body must reach `JSON.parse` through the client's own call.
+        stubs = Faraday::Adapter::Test::Stubs.new do |stub|
+          stub.post("/") do
+            [200, { "Content-Type" => "application/json" }, { result: { tools: [] } }.to_json]
+          end
+        end
+        client = HTTP.new(url: url) { |faraday| faraday.adapter(:test, stubs) }
+        parse = JSON.method(:parse)
+        keyword_options_only_parse = ->(source, **options) { parse.call(source, **options) }
+
+        response = JSON.stub(:parse, keyword_options_only_parse) do
+          client.send_request(request: { jsonrpc: "2.0", id: "test_id", method: "tools/list" })
+        end
+
+        assert_equal({ "result" => { "tools" => [] } }, response)
+      end
+
       def test_send_request_mirrors_x_mcp_header_params_into_mcp_param_headers
         # SEP-2243: on a modern connection, `tools/list` teaches the transport the `x-mcp-header`
         # declarations, and the following `tools/call` mirrors the annotated arguments into


### PR DESCRIPTION
## Motivation and Context

json 3.0, released on 2026-09-07, accepts the options of `JSON.parse` as keywords only, and Faraday's json response middleware, through 2.14.3, hands them over as a positional Hash, which Ruby 3 no longer converts. With both installed, every JSON body the client receives fails inside that middleware, and `MCP::Client::HTTP` reports each request as an internal error. Faraday's main branch passes the options as keywords, but no release carries that yet.

The client already parses streamed bodies and buffered SSE bodies itself; only a JSON body delivered whole by an adapter without streaming support still went through the middleware. The client now parses that body too and no longer registers the middleware, so every body takes `parse_json_buffer` and a malformed one answers `:parse_error` whichever way it arrived. A JSON middleware added through the Faraday customizer block still works, since a body it has parsed already is used as is.

json 3.0 also declares Ruby 2.7 as its floor, but its `load_file` forwards arguments after a leading parameter, `def load_file(filespec, ...)`, syntax Ruby 2.7.3 was the first to parse. On Ruby 2.7.0 through 2.7.2, requiring json 3.0.1 is a `SyntaxError`, so `require "mcp"` fails before any test runs, and the CI job pinned to 2.7.0, the minimum the gemspec supports, fails the whole suite at load time. The Gemfile keeps json below 3.0 on those three patch levels only. Later 2.7 releases and Ruby 3 parse the syntax and stay on whatever json the resolver picks. The line carries a FIXME to drop it once a json release includes ruby/json#1072, whichever version that turns out to be; excluding only the two broken releases would silently trust a 3.0.2 that may not carry the fix.

## How Has This Been Tested?

A new test drives a buffered JSON response through a stand-in `JSON.parse` with the json 3.0 signature, options as keywords only, so on Ruby 3 it failed with the middleware registered whatever json version is installed and passes now. The existing buffered-body test keeps covering the plain path. The full suite passes on Ruby 3.0.7 with json 3.0.1 and faraday 2.14.3, where five client tests failed before.

`gem "json", "3.0.1"; require "json"` raises the `SyntaxError` on Ruby 2.7.0 and loads on 2.7.3 and 2.7.8. With the pin, a fresh `bundle install` on Ruby 2.7.2 resolves json 2.x and `bundle exec rake test` passes.

## Breaking Changes

None. A malformed JSON body delivered by an adapter without streaming support now raises `RequestHandlerError` with `error_type: :parse_error`, as the streamed path already did, instead of `:internal_error` wrapping a `Faraday::ParsingError`. The Gemfile is not part of the gem.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
